### PR TITLE
chore: update add issues to project action

### DIFF
--- a/.github/workflows/add_issue_to_project.yml
+++ b/.github/workflows/add_issue_to_project.yml
@@ -40,7 +40,6 @@ jobs:
               }
             }' -f project=$PROJECT_ID_WW -f issue=$ISSUE_ID -f user=$USER
 
-
       - name: "Add repo identifier label"
         run: |
           gh api graphql -f query='


### PR DESCRIPTION
chore: update add issues to project action

The GitHub projects API has been replaced with ProjectsV2. This PR corrects the add issues to project action.

Also removes the external GH action and replaces with a simple GQL mutation for labelling

There should be no impact on any FE functionality - this affects Penny and I in terms of tracking new issues