### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           type: zip
           directory: dist/libs/wallet-web-${{ matrix.browser }}
           exclusions: '*.zip'
-          filename: ${{ matrix.browser }}.zip
+          filename: vegawallet-${{ matrix.browser }}.zip
       
       - name: Release
         if: ${{ inputs.publish || startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
closes vegaprotocol/devops-infra#1700