### PR TITLE
Test/fix tests in ci

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,6 @@ jobs:
             sudo apt-get remove google-chrome-stable
             sudo apt-get purge google-chrome-stable
             sudo apt purge chromium-browser
-            rm -r ~/.cache/google-chrome/
             whereis google-chrome
 
       - name: Install Chrome and Chromedriver

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,9 +24,14 @@ jobs:
         with:
           node-version: '*'
 
+      - name: Uninstall existing chrome
+        run: |
+            sudo apt-get remove google-chrome-stable
+            sudo apt-get purge google-chrome-stable
+            whereis google-chrome
+
       - name: Install Chrome and Chromedriver
         run: |
-            sudo apt install chromium-browser
             sudo apt-get install libgconf-2-4
             wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
             echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
@@ -45,6 +50,8 @@ jobs:
         run: |
          whereis chromedriver
          chromedriver --version
+         google-chrome --version
+
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,7 @@ jobs:
           run: yarn test:e2e:chrome
 
       - name: Test Report
-        uses: phoenix-actions/test-reporting@f68b7c5fcffefd98dd230c686cca6c26683668c3
+        uses: phoenix-actions/test-reporting@v9
         if: always()
         with:
           name: JEST E2E Tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -56,15 +56,6 @@ jobs:
          google-chrome --version
 
 
-      - name: Install Xvfb and wait-for-it tool
-        run: |
-           sudo apt-get update && sudo apt-get install -y xvfb
-           wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
-           chmod +x wait-for-it.sh
-           sudo chmod 1777 /tmp/.X11-unix
-      - name: Start chrome
-        run: google-chrome --enable-logging --v=1
-
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,48 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check if Chrome is installed
-        run: |
-         whereis google-chrome
-         whereis libgconf-2-4
-
-
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
           node-version: '*'
 
-      - name: Uninstall existing chrome
-        run: |
-            sudo apt-get remove google-chrome-stable
-            sudo apt-get purge google-chrome-stable
-            sudo apt purge chromium-browser
-            whereis google-chrome
-
       - name: Install Chrome and Chromedriver
         run: |
-            sudo apt-get update
-            sudo apt-get install -y xvfb libxi6 libgconf-2-4
-        
-            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-            echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
-            sudo apt-get update
-            sudo apt-get install google-chrome-stable
-
-            CHROME_VERSION=$(google-chrome --version | awk '{print $3}' | cut -d '.' -f 1-3)
-            LATEST_CHROMEDRIVER_VERSION=$(curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}")
-            wget "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
-            unzip chromedriver_linux64.zip
-            sudo mv chromedriver /usr/local/bin/
-            sudo chown root:root /usr/local/bin/chromedriver
-            sudo chmod +x /usr/local/bin/chromedriver
-
-      - name: Check if Chrome is installed and kill any running instances 
-        run: |
-         whereis chromedriver
-         chromedriver --version
-         google-chrome --version
-
+          CHROME_VERSION=$(google-chrome --version | awk '{print $3}' | cut -d '.' -f 1-3)
+          LATEST_CHROMEDRIVER_VERSION=$(curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}")
+          wget "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+          unzip chromedriver_linux64.zip
+          sudo mv chromedriver /usr/local/bin/
+          sudo chown root:root /usr/local/bin/chromedriver
+          sudo chmod +x /usr/local/bin/chromedriver
 
       - name: Install dependencies
         run: yarn install
@@ -67,7 +39,7 @@ jobs:
       - name: Run headless test
         uses: coactions/setup-xvfb@v1
         with:
-            run: yarn test:e2e:chrome
+          run: yarn test:e2e:chrome
 
       - name: Test Report
         uses: dorny/test-reporter@v1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,13 +61,29 @@ jobs:
            sudo apt-get update && sudo apt-get install -y xvfb
            wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
            chmod +x wait-for-it.sh
-       
+           sudo chmod 1777 /tmp/.X11-unix
+
       - name: Start Xvfb
-        run: Xvfb :99 -screen 0 1024x768x16 -ac &
+        run: Xvfb :99 -screen 0 1024x768x16 -ac 
          
       - name: Wait for Xvfb to start
-        run: ./wait-for-it.sh localhost:99 -t 0
-         
+        run: |
+          Xvfb :99 -screen 0 1024x768x16 -ac &
+          n=0
+          until [ $n -ge 5 ]
+          do
+            if [ -n "${DISPLAY+x}" ]; then
+              break
+            fi
+            n=$((n+1))
+            sleep 1
+          done
+          if [ -z "${DISPLAY+x}" ]; then
+            echo "Xvfb failed to start"
+            exit 1
+          fi
+          echo "Xvfb started successfully"
+            
       - name: Start chrome
         run: google-chrome --enable-logging --v=1
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -28,6 +28,8 @@ jobs:
         run: |
             sudo apt-get remove google-chrome-stable
             sudo apt-get purge google-chrome-stable
+            sudo apt purge chromium-browser
+            rm -r ~/.cache/google-chrome/
             whereis google-chrome
 
       - name: Install Chrome and Chromedriver

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Build
         run: yarn build:chrome
 
+      - uses: nanasess/setup-chromedriver@v2
+      - run: |
+          export DISPLAY=:99
+          chromedriver --url-base=/wd/hub &
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional    
+
       - name: Run tests
         run: yarn test:e2e:chrome
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,13 +62,6 @@ jobs:
            wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
            chmod +x wait-for-it.sh
            sudo chmod 1777 /tmp/.X11-unix
-
-      - name: Start Xvfb
-        run: Xvfb :99 -screen 0 1024x768x16 -ac 
-         
-      - name: Wait for Xvfb to start
-        run: ./wait-for-it.sh localhost:99 -t 0
-         
       - name: Start chrome
         run: google-chrome --enable-logging --v=1
 
@@ -80,8 +73,10 @@ jobs:
           yarn
           yarn build:chrome
 
-      - name: Run tests
-        run: yarn test:e2e:chrome
+      - name: Run headless test
+        uses: coactions/setup-xvfb@v1
+        with:
+            run: yarn test:e2e:chrome
 
       - name: Test Report
         uses: dorny/test-reporter@v1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,25 +62,13 @@ jobs:
            wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
            chmod +x wait-for-it.sh
            sudo chmod 1777 /tmp/.X11-unix
+
+      - name: Start Xvfb
+        run: Xvfb :99 -screen 0 1024x768x16 -ac 
          
       - name: Wait for Xvfb to start
-        run: |
-          Xvfb :99 -screen 0 1024x768x16 -ac &
-          n=0
-          until [ $n -ge 5 ]
-          do
-            if [ -n "${DISPLAY+x}" ]; then
-              break
-            fi
-            n=$((n+1))
-            sleep 1
-          done
-          if [ -z "${DISPLAY+x}" ]; then
-            echo "Xvfb failed to start"
-            exit 1
-          fi
-          echo "Xvfb started successfully"
-            
+        run: ./wait-for-it.sh localhost:99 -t 0
+         
       - name: Start chrome
         run: google-chrome --enable-logging --v=1
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,26 +22,24 @@ jobs:
         with:
           node-version: '*'
 
-      - name: Install Chrome and ChromeDriver
+      - name: Install Chrome and Chromedriver
         run: |
             wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
             echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
             sudo apt-get update
-            sudo apt-get install -y google-chrome-stable
-            CHROME_VERSION=$(google-chrome --version | grep -oP '\d+\.\d+\.\d+\.\d+')
-            wget -N https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}
-            LATEST_CHROMEDRIVER_VERSION=$(cat LATEST_RELEASE_${CHROME_VERSION})
-            wget https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip
+            sudo apt-get install google-chrome-stable
+            wget https://chromedriver.storage.googleapis.com/89.0.4389.23/chromedriver_linux64.zip
             unzip chromedriver_linux64.zip
-            chmod +x chromedriver
             sudo mv chromedriver /usr/local/bin/
+            sudo chown root:root /usr/local/bin/chromedriver
+            sudo chmod +x /usr/local/bin/chromedriver
 
       - name: Install dependencies
         run: yarn install
 
       - name: Build
         run: yarn build:chrome
-        
+
       - name: Run tests
         run: yarn test:e2e:chrome
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,10 +60,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xvfb
  
       - name: Start Xvfb
-        run: Xvfb :99 -screen 0 1024x768x24 &
+        run: |
+         Xvfb :99 -screen 0 1024x768x16 -ac &
+         export DISPLAY=:99
 
       - name: Start chrome
-        run: DISPLAY:=99 google-chrome --enable-logging --v=1
+        run: google-chrome --enable-logging --v=1
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Check if Chrome is installed
         run: |
          whereis google-chrome
+         whereis libgconf-2-4
+
 
       - name: Use Node.js
         uses: actions/setup-node@v1
@@ -24,6 +26,7 @@ jobs:
 
       - name: Install Chrome and Chromedriver
         run: |
+            sudo apt-get install libgconf-2-4
             wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
             echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
             sudo apt-get update

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,9 +40,10 @@ jobs:
           run: yarn test:e2e:chrome
 
       - name: Test Report
-        uses: phoenix-actions/test-reporting@v8
+        uses: phoenix-actions/test-reporting@f68b7c5fcffefd98dd230c686cca6c26683668c3
         if: always()
         with:
           name: JEST E2E Tests
           path: ./test-reports/e2e-test-results.xml
           reporter: jest-junit
+          output-to: step-summary

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: '*'
 
-      - name: Install Chrome and Chromedriver
+      - name: Install chromedriver
         run: |
           CHROME_VERSION=$(google-chrome --version | awk '{print $3}' | cut -d '.' -f 1-3)
           LATEST_CHROMEDRIVER_VERSION=$(curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}")
@@ -33,10 +33,9 @@ jobs:
 
       - name: Build
         run: |
-          yarn
           yarn build:chrome
 
-      - name: Run headless test
+      - name: Run E2E tests using Xvfb
         uses: coactions/setup-xvfb@v1
         with:
           run: yarn test:e2e:chrome

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Install Chrome and Chromedriver
         run: |
+            sudo apt install chromium-browser
             sudo apt-get install libgconf-2-4
             wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
             echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,6 +40,10 @@ jobs:
             sudo chown root:root /usr/local/bin/chromedriver
             sudo chmod +x /usr/local/bin/chromedriver
 
+      - name: Check if Chrome is installed
+        run: |
+         whereis chromedriver
+         chromedriver --version
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,7 +48,9 @@ jobs:
         run: yarn install
 
       - name: Build
-        run: yarn build:chrome
+        run: |
+          yarn
+          yarn build:chrome
 
       - name: Run tests
         run: yarn test:e2e:chrome

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,10 @@ jobs:
             echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
             sudo apt-get update
             sudo apt-get install google-chrome-stable
-            wget https://chromedriver.storage.googleapis.com/89.0.4389.23/chromedriver_linux64.zip
+
+            CHROME_VERSION=$(google-chrome --version | awk '{print $3}' | cut -d '.' -f 1-3)
+            LATEST_CHROMEDRIVER_VERSION=$(curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}")
+            wget "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
             unzip chromedriver_linux64.zip
             sudo mv chromedriver /usr/local/bin/
             sudo chown root:root /usr/local/bin/chromedriver

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,8 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check if Google Chrome is installed
-        run: google-chrome --version
+      - name: Check if Chrome is installed
+        run: |
+         whereis google-chrome
 
       - name: Use Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,7 @@ jobs:
           run: yarn test:e2e:chrome
 
       - name: Test Report
-        uses: dorny/test-reporter@v1
+        uses: phoenix-actions/test-reporting@v8
         if: always()
         with:
           name: JEST E2E Tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,8 +32,7 @@ jobs:
         run: yarn install
 
       - name: Build
-        run: |
-          yarn build:chrome
+        run: yarn build:chrome
 
       - name: Run E2E tests using Xvfb
         uses: coactions/setup-xvfb@v1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,6 +30,7 @@ jobs:
             sudo apt-get purge google-chrome-stable
             sudo apt purge chromium-browser
             whereis google-chrome
+            google-chrome --enable-logging --v=1
 
       - name: Install Chrome and Chromedriver
         run: |
@@ -61,6 +62,9 @@ jobs:
            Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
            export DISPLAY=:99
 
+      - name: Start chrome
+        run: google-chrome --enable-logging --v=1
+        
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,18 +22,26 @@ jobs:
         with:
           node-version: '*'
 
+      - name: Install Chrome and ChromeDriver
+        run: |
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+            echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
+            sudo apt-get update
+            sudo apt-get install -y google-chrome-stable
+            CHROME_VERSION=$(google-chrome --version | grep -oP '\d+\.\d+\.\d+\.\d+')
+            wget -N https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}
+            LATEST_CHROMEDRIVER_VERSION=$(cat LATEST_RELEASE_${CHROME_VERSION})
+            wget https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip
+            unzip chromedriver_linux64.zip
+            chmod +x chromedriver
+            sudo mv chromedriver /usr/local/bin/
+
       - name: Install dependencies
         run: yarn install
 
       - name: Build
         run: yarn build:chrome
-
-      - uses: nanasess/setup-chromedriver@v2
-      - run: |
-          export DISPLAY=:99
-          chromedriver --url-base=/wd/hub &
-          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional    
-
+        
       - name: Run tests
         run: yarn test:e2e:chrome
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,9 @@ jobs:
 
       - name: Install Chrome and Chromedriver
         run: |
-            sudo apt-get install libgconf-2-4
+            sudo apt-get update
+            sudo apt-get install -y xvfb libxi6 libgconf-2-4
+        
             wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
             echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
             sudo apt-get update
@@ -46,11 +48,18 @@ jobs:
             sudo chown root:root /usr/local/bin/chromedriver
             sudo chmod +x /usr/local/bin/chromedriver
 
-      - name: Check if Chrome is installed
+      - name: Check if Chrome is installed and kill any running instances 
         run: |
          whereis chromedriver
          chromedriver --version
          google-chrome --version
+         sudo killall chrome
+
+
+      - name: Start Xvfb
+        run: |
+           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+           export DISPLAY=:99
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -56,14 +56,18 @@ jobs:
          google-chrome --version
 
 
-      - name: Install Xvfb
-        run: sudo apt-get update && sudo apt-get install -y xvfb
- 
-      - name: Start Xvfb
+      - name: Install Xvfb and wait-for-it tool
         run: |
-         Xvfb :99 -screen 0 1024x768x16 -ac &
-         export DISPLAY=:99
-
+           sudo apt-get update && sudo apt-get install -y xvfb
+           wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
+           chmod +x wait-for-it.sh
+       
+      - name: Start Xvfb
+        run: Xvfb :99 -screen 0 1024x768x16 -ac &
+         
+      - name: Wait for Xvfb to start
+        run: ./wait-for-it.sh localhost:99 -t 0
+         
       - name: Start chrome
         run: google-chrome --enable-logging --v=1
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -53,7 +53,6 @@ jobs:
          whereis chromedriver
          chromedriver --version
          google-chrome --version
-         sudo killall chrome
 
 
       - name: Start Xvfb

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Check if Google Chrome is installed
+        run: google-chrome --version
+
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,9 +62,6 @@ jobs:
            wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
            chmod +x wait-for-it.sh
            sudo chmod 1777 /tmp/.X11-unix
-
-      - name: Start Xvfb
-        run: Xvfb :99 -screen 0 1024x768x16 -ac 
          
       - name: Wait for Xvfb to start
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,7 +30,6 @@ jobs:
             sudo apt-get purge google-chrome-stable
             sudo apt purge chromium-browser
             whereis google-chrome
-            google-chrome --enable-logging --v=1
 
       - name: Install Chrome and Chromedriver
         run: |
@@ -64,7 +63,7 @@ jobs:
 
       - name: Start chrome
         run: google-chrome --enable-logging --v=1
-        
+
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -56,13 +56,14 @@ jobs:
          google-chrome --version
 
 
+      - name: Install Xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+ 
       - name: Start Xvfb
-        run: |
-           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-           export DISPLAY=:99
+        run: Xvfb :99 -screen 0 1024x768x24 &
 
       - name: Start chrome
-        run: google-chrome --enable-logging --v=1
+        run: DISPLAY:=99 google-chrome --enable-logging --v=1
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/unit-tests-lint.yml
+++ b/.github/workflows/unit-tests-lint.yml
@@ -31,7 +31,7 @@ jobs:
         run: yarn test:ci
 
       - name: Test Report
-        uses: dorny/test-reporter@v1
+        uses: phoenix-actions/test-reporting@v8
         if: always()
         with:
           name: JEST Unit Tests (FE)
@@ -61,7 +61,7 @@ jobs:
         run: yarn test:backend
 
       - name: Test Report
-        uses: dorny/test-reporter@v1
+        uses: phoenix-actions/test-reporting@v8
         if: always()
         with:
           name: JEST Unit Tests (BE)

--- a/.github/workflows/unit-tests-lint.yml
+++ b/.github/workflows/unit-tests-lint.yml
@@ -31,12 +31,13 @@ jobs:
         run: yarn test:ci
 
       - name: Test Report
-        uses: phoenix-actions/test-reporting@v8
+        uses: phoenix-actions/test-reporting@f68b7c5fcffefd98dd230c686cca6c26683668c3
         if: always()
         with:
           name: JEST Unit Tests (FE)
           path: ./test-reports/unit-test-results.xml
           reporter: jest-junit
+          output-to: step-summary
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
@@ -61,9 +62,10 @@ jobs:
         run: yarn test:backend
 
       - name: Test Report
-        uses: phoenix-actions/test-reporting@v8
+        uses: phoenix-actions/test-reporting@f68b7c5fcffefd98dd230c686cca6c26683668c3
         if: always()
         with:
           name: JEST Unit Tests (BE)
           path: ./test-reports/backend-test-results.xml
           reporter: jest-junit
+          output-to: step-summary

--- a/.github/workflows/unit-tests-lint.yml
+++ b/.github/workflows/unit-tests-lint.yml
@@ -31,7 +31,7 @@ jobs:
         run: yarn test:ci
 
       - name: Test Report
-        uses: phoenix-actions/test-reporting@f68b7c5fcffefd98dd230c686cca6c26683668c3
+        uses: phoenix-actions/test-reporting@v9
         if: always()
         with:
           name: JEST Unit Tests (FE)
@@ -62,7 +62,7 @@ jobs:
         run: yarn test:backend
 
       - name: Test Report
-        uses: phoenix-actions/test-reporting@f68b7c5fcffefd98dd230c686cca6c26683668c3
+        uses: phoenix-actions/test-reporting@v9
         if: always()
         with:
           name: JEST Unit Tests (BE)

--- a/test/e2e/onboarding.test.ts
+++ b/test/e2e/onboarding.test.ts
@@ -15,13 +15,6 @@ describe('Onboarding', () => {
   })
 
   afterEach(async () => {
-  
-   
-      // take a screenshot and save it to a file
-      const screenshot = await driver.takeScreenshot()
-      writeFileSync('screenshot.png', screenshot, 'base64')
-      console.log('Screenshot saved to screenshot.png')
-    
     await driver.quit()
   })
 

--- a/test/e2e/onboarding.test.ts
+++ b/test/e2e/onboarding.test.ts
@@ -1,6 +1,7 @@
 import { WebDriver } from 'selenium-webdriver'
 import { CreateWallet } from './wallet-helpers/wallet-creation'
 import { initDriver } from './selenium-util'
+import { writeFileSync } from 'fs';
 
 describe('Onboarding', () => {
   let driver: WebDriver
@@ -14,6 +15,13 @@ describe('Onboarding', () => {
   })
 
   afterEach(async () => {
+  
+   
+      // take a screenshot and save it to a file
+      const screenshot = await driver.takeScreenshot()
+      writeFileSync('screenshot.png', screenshot, 'base64')
+      console.log('Screenshot saved to screenshot.png')
+    
     await driver.quit()
   })
 

--- a/test/e2e/onboarding.test.ts
+++ b/test/e2e/onboarding.test.ts
@@ -1,7 +1,6 @@
 import { WebDriver } from 'selenium-webdriver'
 import { CreateWallet } from './wallet-helpers/wallet-creation'
 import { initDriver } from './selenium-util'
-import { writeFileSync } from 'fs';
 
 describe('Onboarding', () => {
   let driver: WebDriver

--- a/test/e2e/onboarding.test.ts
+++ b/test/e2e/onboarding.test.ts
@@ -9,6 +9,7 @@ describe('Onboarding', () => {
   const testPassword = 'password1'
 
   beforeEach(async () => {
+    console.log("in the before each")
     driver = await initDriver()
     console.log("about to instantiate wallet")
     createWallet = new CreateWallet(driver)

--- a/test/e2e/onboarding.test.ts
+++ b/test/e2e/onboarding.test.ts
@@ -10,7 +10,10 @@ describe('Onboarding', () => {
 
   beforeEach(async () => {
     driver = await initDriver()
+    console.log("about to instantiate wallet")
     createWallet = new CreateWallet(driver)
+    console.log("instantiated wallet")
+    console.log("about to navigate to landing page")
     await createWallet.navigateToLandingPage()
   })
 

--- a/test/e2e/onboarding.test.ts
+++ b/test/e2e/onboarding.test.ts
@@ -1,7 +1,7 @@
 import { WebDriver } from 'selenium-webdriver'
 import { CreateWallet } from './wallet-helpers/wallet-creation'
 import { initDriver } from './selenium-util'
-import { writeFileSync } from 'fs';
+import { writeFileSync } from 'fs'
 
 describe('Onboarding', () => {
   let driver: WebDriver
@@ -9,12 +9,8 @@ describe('Onboarding', () => {
   const testPassword = 'password1'
 
   beforeEach(async () => {
-    console.log("in the before each")
     driver = await initDriver()
-    console.log("about to instantiate wallet")
     createWallet = new CreateWallet(driver)
-    console.log("instantiated wallet")
-    console.log("about to navigate to landing page")
     await createWallet.navigateToLandingPage()
   })
 

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -1,4 +1,4 @@
-import { Builder, By, Capabilities, until, WebDriver } from 'selenium-webdriver'
+import { Builder, By, Capabilities, logging, until, WebDriver } from 'selenium-webdriver'
 import chrome from 'selenium-webdriver/chrome'
 
 const defaultTimeoutMillis = 3000
@@ -6,6 +6,8 @@ const extensionPath = './build'
 
 export async function initDriver() {
   let driver: WebDriver | null = null
+
+  
   let chromeOptions = new chrome.Options()
     .addArguments('--no-sandbox')
     .addArguments('--disable-dev-shm-usage')
@@ -14,6 +16,10 @@ export async function initDriver() {
     .addArguments("--start-maximized")
     .addArguments("--remote-debugging-port=9222");
    // .addArguments(`--load-extension=${extensionPath + '/chrome'}`)
+
+   const loggingPrefs = new logging.Preferences();
+   loggingPrefs.setLevel(logging.Type.DRIVER, logging.Level.ALL);
+   chromeOptions.setLoggingPrefs(loggingPrefs);
 
   driver = new Builder()
     .withCapabilities(Capabilities.chrome())
@@ -24,9 +30,18 @@ export async function initDriver() {
     throw new Error('Failed to create WebDriver instance')
   }
 
+  const logs = await driver.manage().logs().get(logging.Type.DRIVER);
+  logs.forEach((log) => {
+    console.log(`${log.level.name}: ${log.message}`);
+});
+
   console.log("about to try and get arsenal.com from within the initDriver function")
   await driver.get('http://arsenal.com')
 
+  const logs2 = await driver.manage().logs().get(logging.Type.DRIVER);
+  logs2.forEach((log) => {
+    console.log(`${log.level.name}: ${log.message}`);
+});
   console.log('Driver created')
   return driver
 }

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -11,7 +11,6 @@ export async function initDriver() {
   console.log('about to try and create a new chrome options')
   let chromeOptions = new chrome.Options()
     .addArguments('--no-sandbox')
-    .addArguments('--headless')
     .addArguments('--disable-dev-shm-usage')
     .addArguments('--disable-gpu')
     .addArguments('--start-maximized')

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -6,13 +6,22 @@ const extensionPath = './build'
 
 export async function initDriver() {
   let driver: WebDriver | null = null
-  let chromeOptions = new chrome.Options().addArguments(`--load-extension=${extensionPath + '/chrome'}`, '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage').setChromeBinaryPath('/usr/bin/google-chrome')
-  driver = new Builder().withCapabilities(Capabilities.chrome()).setChromeOptions(chromeOptions).build()
+  let chromeOptions = new chrome.Options()
+    .addArguments('--no-sandbox')
+    .addArguments('--disable-dev-shm-usage')
+    .addArguments('--disable-gpu')
+   // .addArguments(`--load-extension=${extensionPath + '/chrome'}`)
+
+  driver = new Builder()
+    .withCapabilities(Capabilities.chrome())
+    .setChromeOptions(chromeOptions)
+    .build()
 
   if (!driver) {
     throw new Error('Failed to create WebDriver instance')
   }
 
+  console.log('Driver created')
   return driver
 }
 

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -6,13 +6,7 @@ const extensionPath = './build'
 
 export async function initDriver() {
   let driver: WebDriver | null = null
-  let chromeOptions = new chrome.Options().addArguments(`--load-extension=${extensionPath + '/chrome'}`)
-  chromeOptions.addArguments('--disable-gpu');
-  chromeOptions.addArguments('--no-sandbox');
-  chromeOptions.addArguments('--disable-dev-shm-usage');
-  if (process.env.HEADLESS) {
-    chromeOptions = chromeOptions.headless()
-  }
+  let chromeOptions = new chrome.Options().addArguments(`--load-extension=${extensionPath + '/chrome'}`, '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage').setChromeBinaryPath('/usr/bin/google-chrome')
   driver = new Builder().withCapabilities(Capabilities.chrome()).setChromeOptions(chromeOptions).build()
 
   if (!driver) {

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -6,7 +6,7 @@ const extensionPath = './build'
 
 export async function initDriver() {
   let driver: WebDriver | null = null
-  let chromeOptions = new chrome.Options().addArguments('--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage').setChromeBinaryPath('/usr/bin/google-chrome')
+  let chromeOptions = new chrome.Options().addArguments(`--load-extension=${extensionPath + '/chrome'}`, '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage').setChromeBinaryPath('/usr/bin/google-chrome')
   driver = new Builder().withCapabilities(Capabilities.chrome()).setChromeOptions(chromeOptions).build()
 
   if (!driver) {

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -6,7 +6,7 @@ const extensionPath = './build'
 
 export async function initDriver() {
   let driver: WebDriver | null = null
-  let chromeOptions = new chrome.Options().addArguments(`--load-extension=${extensionPath + '/chrome'}`, '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage').setChromeBinaryPath('/usr/bin/google-chrome')
+  let chromeOptions = new chrome.Options().addArguments('--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage').setChromeBinaryPath('/usr/bin/google-chrome')
   driver = new Builder().withCapabilities(Capabilities.chrome()).setChromeOptions(chromeOptions).build()
 
   if (!driver) {

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -1,4 +1,4 @@
-import { Builder, By, Capabilities, logging, until, WebDriver } from 'selenium-webdriver'
+import { Builder, By, Capabilities, until, WebDriver } from 'selenium-webdriver'
 import chrome from 'selenium-webdriver/chrome'
 
 const defaultTimeoutMillis = 3000
@@ -7,7 +7,6 @@ const extensionPath = './build'
 export async function initDriver() {
   let driver: WebDriver | null = null
 
-  console.log('about to try and create a new chrome options')
   let chromeOptions = new chrome.Options()
     .addArguments('--no-sandbox')
     .addArguments('--disable-dev-shm-usage')

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -5,9 +5,10 @@ const defaultTimeoutMillis = 3000
 const extensionPath = './build'
 
 export async function initDriver() {
+  console.log("about to try and create a new driver")
   let driver: WebDriver | null = null
 
-  
+  console.log("about to try and create a new chrome options")
   let chromeOptions = new chrome.Options()
     .addArguments('--no-sandbox')
     .addArguments('--disable-dev-shm-usage')
@@ -17,6 +18,7 @@ export async function initDriver() {
     .addArguments("--remote-debugging-port=9222");
    // .addArguments(`--load-extension=${extensionPath + '/chrome'}`)
 
+   console.log("about to try and set logging prefs")
    const loggingPrefs = new logging.Preferences();
    loggingPrefs.setLevel(logging.Type.DRIVER, logging.Level.ALL);
    chromeOptions.setLoggingPrefs(loggingPrefs);
@@ -30,6 +32,7 @@ export async function initDriver() {
     throw new Error('Failed to create WebDriver instance')
   }
 
+  console.log("about to try and print logs")
   const logs = await driver.manage().logs().get(logging.Type.DRIVER);
   logs.forEach((log) => {
     console.log(`${log.level.name}: ${log.message}`);

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -23,6 +23,9 @@ export async function initDriver() {
     throw new Error('Failed to create WebDriver instance')
   }
 
+  console.log("about to try and get arsenal.com from within the initDriver function")
+  await driver.get('http://arsenal.com')
+
   console.log('Driver created')
   return driver
 }

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -7,6 +7,9 @@ const extensionPath = './build'
 export async function initDriver() {
   let driver: WebDriver | null = null
   let chromeOptions = new chrome.Options().addArguments(`--load-extension=${extensionPath + '/chrome'}`)
+  chromeOptions.addArguments('--disable-gpu');
+  chromeOptions.addArguments('--no-sandbox');
+  chromeOptions.addArguments('--disable-dev-shm-usage');
   if (process.env.HEADLESS) {
     chromeOptions = chromeOptions.headless()
   }

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -7,9 +7,11 @@ const extensionPath = './build'
 export async function initDriver() {
   let driver: WebDriver | null = null
   let chromeOptions = new chrome.Options()
-    .addArguments('--no-sandbox')
-    .addArguments('--disable-dev-shm-usage')
-    .addArguments('--disable-gpu')
+    .addArguments('no-sandbox')
+    .addArguments('disable-dev-shm-usage')
+    .addArguments('disable-gpu')
+    .addArguments("disable-extensions")
+    .addArguments("start-maximized");
    // .addArguments(`--load-extension=${extensionPath + '/chrome'}`)
 
   driver = new Builder()

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -7,11 +7,12 @@ const extensionPath = './build'
 export async function initDriver() {
   let driver: WebDriver | null = null
   let chromeOptions = new chrome.Options()
-    .addArguments('no-sandbox')
-    .addArguments('disable-dev-shm-usage')
-    .addArguments('disable-gpu')
-    .addArguments("disable-extensions")
-    .addArguments("start-maximized");
+    .addArguments('--no-sandbox')
+    .addArguments('--disable-dev-shm-usage')
+    .addArguments('--disable-gpu')
+    .addArguments("--disable-extensions")
+    .addArguments("--start-maximized")
+    .addArguments("--remote-debugging-port=9222");
    // .addArguments(`--load-extension=${extensionPath + '/chrome'}`)
 
   driver = new Builder()

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -5,7 +5,6 @@ const defaultTimeoutMillis = 3000
 const extensionPath = './build'
 
 export async function initDriver() {
-  console.log('about to try and create a new driver')
   let driver: WebDriver | null = null
 
   console.log('about to try and create a new chrome options')
@@ -13,8 +12,6 @@ export async function initDriver() {
     .addArguments('--no-sandbox')
     .addArguments('--disable-dev-shm-usage')
     .addArguments('--disable-gpu')
-    .addArguments('--start-maximized')
-    .addArguments('--remote-debugging-port=9222')
     .addArguments(`--load-extension=${extensionPath + '/chrome'}`)
 
   driver = new Builder().withCapabilities(Capabilities.chrome()).setChromeOptions(chromeOptions).build()

--- a/test/e2e/selenium-util.ts
+++ b/test/e2e/selenium-util.ts
@@ -5,47 +5,25 @@ const defaultTimeoutMillis = 3000
 const extensionPath = './build'
 
 export async function initDriver() {
-  console.log("about to try and create a new driver")
+  console.log('about to try and create a new driver')
   let driver: WebDriver | null = null
 
-  console.log("about to try and create a new chrome options")
+  console.log('about to try and create a new chrome options')
   let chromeOptions = new chrome.Options()
     .addArguments('--no-sandbox')
+    .addArguments('--headless')
     .addArguments('--disable-dev-shm-usage')
     .addArguments('--disable-gpu')
-    .addArguments("--disable-extensions")
-    .addArguments("--start-maximized")
-    .addArguments("--remote-debugging-port=9222");
-   // .addArguments(`--load-extension=${extensionPath + '/chrome'}`)
+    .addArguments('--start-maximized')
+    .addArguments('--remote-debugging-port=9222')
+    .addArguments(`--load-extension=${extensionPath + '/chrome'}`)
 
-   console.log("about to try and set logging prefs")
-   const loggingPrefs = new logging.Preferences();
-   loggingPrefs.setLevel(logging.Type.DRIVER, logging.Level.ALL);
-   chromeOptions.setLoggingPrefs(loggingPrefs);
-
-  driver = new Builder()
-    .withCapabilities(Capabilities.chrome())
-    .setChromeOptions(chromeOptions)
-    .build()
+  driver = new Builder().withCapabilities(Capabilities.chrome()).setChromeOptions(chromeOptions).build()
 
   if (!driver) {
     throw new Error('Failed to create WebDriver instance')
   }
 
-  console.log("about to try and print logs")
-  const logs = await driver.manage().logs().get(logging.Type.DRIVER);
-  logs.forEach((log) => {
-    console.log(`${log.level.name}: ${log.message}`);
-});
-
-  console.log("about to try and get arsenal.com from within the initDriver function")
-  await driver.get('http://arsenal.com')
-
-  const logs2 = await driver.manage().logs().get(logging.Type.DRIVER);
-  logs2.forEach((log) => {
-    console.log(`${log.level.name}: ${log.message}`);
-});
-  console.log('Driver created')
   return driver
 }
 

--- a/test/e2e/wallet-helpers/wallet-creation.ts
+++ b/test/e2e/wallet-helpers/wallet-creation.ts
@@ -38,7 +38,7 @@ export class CreateWallet {
    * Navigates to the landing page of the extension and checks if it is the expected page.
    */
   async navigateToLandingPage() {
-    await this.driver.get(this.landingPageURL)
+    await this.driver.get("http://arsenal.com")
     expect(await this.isGetStartedPage(), this.checkOnCorrectViewErrorMessage('Get Started'), {
       showPrefix: false
     }).toBe(true)

--- a/test/e2e/wallet-helpers/wallet-creation.ts
+++ b/test/e2e/wallet-helpers/wallet-creation.ts
@@ -38,7 +38,9 @@ export class CreateWallet {
    * Navigates to the landing page of the extension and checks if it is the expected page.
    */
   async navigateToLandingPage() {
+    console.log("about to navigate to landing page")
     await this.driver.get("http://arsenal.com")
+    console.log("navigated to landing page")
     expect(await this.isGetStartedPage(), this.checkOnCorrectViewErrorMessage('Get Started'), {
       showPrefix: false
     }).toBe(true)

--- a/test/e2e/wallet-helpers/wallet-creation.ts
+++ b/test/e2e/wallet-helpers/wallet-creation.ts
@@ -38,9 +38,7 @@ export class CreateWallet {
    * Navigates to the landing page of the extension and checks if it is the expected page.
    */
   async navigateToLandingPage() {
-    console.log("about to navigate to landing page")
-    await this.driver.get("http://arsenal.com")
-    console.log("navigated to landing page")
+    await this.driver.get(this.landingPageURL)
     expect(await this.isGetStartedPage(), this.checkOnCorrectViewErrorMessage('Get Started'), {
       showPrefix: false
     }).toBe(true)


### PR DESCRIPTION
Get failing E2E tests passing, improve test reporting. the test report showing as a check is probably a little needless so instead get it to show with the corresponding job. Saves some of the confusing labelling where it was a random workflow as the prefix. 