### PR TITLE
ci: fix deprecated set-output commands

### DIFF
--- a/.github/workflows/approbation.yml
+++ b/.github/workflows/approbation.yml
@@ -30,7 +30,7 @@ jobs:
             --categories="specs/user-interface/categories.json" \
             --show-mystery --category-stats --output-jenkins
           results=$(cat results/jenkins.txt)
-          echo "::set-output name=file-main::$results"
+          echo "file-main=$results" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -55,7 +55,7 @@ jobs:
             --categories="specs/user-interface/categories.json" \
             --show-mystery --category-stats --output-jenkins
           results=$(cat results/jenkins.txt)
-          echo "::set-output name=file::$results"
+          echo "file=$results" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
         uses: peter-evans/find-comment@v1


### PR DESCRIPTION
`set-output` was deprecated 2023-05-31 so this is an attempt at fixing it :)