### PR TITLE
fix: Prevent read of encrypted data while locked

### DIFF
--- a/test/e2e/transaction.spec.ts
+++ b/test/e2e/transaction.spec.ts
@@ -9,6 +9,8 @@ import { Transaction } from './page-objects/transaction'
 import { openNewWindowAndSwitchToIt } from './selenium-util'
 import { closeServerAndWait, server } from './wallet-helpers/http-server'
 import test from '../../config/test'
+import { Login } from './page-objects/login'
+import { loginButton } from '../../frontend/locator-ids'
 
 describe('transactions', () => {
   let driver: WebDriver
@@ -116,6 +118,18 @@ describe('transactions', () => {
     await transaction.rejectTransaction()
     const resp = await vegaAPI.getTransactionResult()
     expect(resp).toBe('Transaction denied')
+    await viewWallet.checkOnViewWalletPage()
+  })
+
+  it('can send a transaction to a locked wallet and respond on unlock', async () => {
+    const keys = await vegaAPI.listKeys()
+    await apiHelper.lockWallet()
+    await navigateToLandingPage(driver)
+    await vegaAPI.sendTransaction(keys[0].publicKey, { transfer: transferReq })
+    const login = new Login(driver)
+    await login.login()
+    await transaction.checkOnTransactionPage()
+    await transaction.rejectTransaction()
     await viewWallet.checkOnViewWalletPage()
   })
 

--- a/web-extension/backend/client-ns.js
+++ b/web-extension/backend/client-ns.js
@@ -62,23 +62,25 @@ export default function init({ onerror, settings, wallets, networks, connections
           throw new JSONRPCServer.Error(...Errors.UNKNOWN_PUBLIC_KEY)
         }
 
-        const key = await wallets.getKeyByPublicKey({
+        const keyInfo = await wallets.getKeyInfo({
           publicKey: params.publicKey
         })
 
-        if (key == null) throw new JSONRPCServer.Error(...Errors.UNKNOWN_PUBLIC_KEY)
+        if (keyInfo == null) throw new JSONRPCServer.Error(...Errors.UNKNOWN_PUBLIC_KEY)
 
         const approved = await interactor.reviewTransaction({
           transaction: params.transaction,
           publicKey: params.publicKey,
-          name: key.name,
-          wallet: key.wallet,
+          name: keyInfo.name,
+          wallet: keyInfo.wallet,
           sendingMode: params.sendingMode,
           origin: context.origin,
           receivedAt
         })
 
         if (approved === false) throw new JSONRPCServer.Error(...Errors.TRANSACTION_DENIED)
+
+        const key = await wallets.getKeypair({ publicKey: params.publicKey })
 
         const selectedNetwork = await settings.get('selectedNetwork')
         const network = await networks.get(selectedNetwork)

--- a/web-extension/backend/wallets.js
+++ b/web-extension/backend/wallets.js
@@ -12,7 +12,11 @@ export class WalletCollection {
     return this.store.get(name)
   }
 
-  async getKeyByPublicKey({ publicKey }) {
+  async getKeyInfo({ publicKey }) {
+    return this.index.get(publicKey)
+  }
+
+  async getKeypair({ publicKey }) {
     return this.store.transaction(async (store) => {
       const { wallet } = await this.index.get(publicKey)
       if (wallet == null) return

--- a/web-extension/test/wallets.spec.js
+++ b/web-extension/test/wallets.spec.js
@@ -1,0 +1,29 @@
+import { WalletCollection } from '../backend/wallets.js'
+import ConcurrentStorage from '../lib/concurrent-storage.js'
+import EncryptedStorage from '../lib/encrypted-storage.js'
+
+
+describe('wallets', () => {
+  it('should be able to list public key info while locked', async () => {
+    const enc = new EncryptedStorage(new Map(), { memory: 10, iterations: 1 })
+    await enc.create('p')
+
+    const wallets = new WalletCollection({
+      walletsStore: new ConcurrentStorage(enc),
+      publicKeyIndexStore: new ConcurrentStorage(new Map())
+    })
+
+    await wallets.import({ name: 'wallet 1', recoveryPhrase: await wallets.generateRecoveryPhrase() })
+
+    await wallets.generateKey({ wallet: 'wallet 1', name: 'key 1' })
+
+    const keys = await wallets.listKeys({ wallet: 'wallet 1' })
+
+    expect(keys.length).toBe(1)
+
+    await enc.lock()
+
+    expect(enc.isLocked).toBe(true)
+    expect(await wallets.getKeyInfo({ publicKey: keys[0].publicKey })).toHaveProperty('publicKey', keys[0].publicKey)
+  })
+})


### PR DESCRIPTION
This could be triggered by sending a transaction while the wallet was locked, since before asking for user approval, the extension will try to load wallet info, but this is encrypted