### PR TITLE
test: add a default configuration for debugging E2E in VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 /test/test-reports
 /test/test-screenshots
 /test/e2e/firefox-profile
-
+/.vscode/launch.json
 # production
 /build
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug E2E Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "yarn",
+      "args": ["test:e2e:chrome", "-t", "the test you want to debug"],
+      "runtimeArgs": ["--inspect-brk"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}


### PR DESCRIPTION
Debugging out of the box with VSCode SUCKS. This should enable adding breakpoints and stepping through the E2E tests and debug in a more sane way. Change the test in the launch.json (or browser etc), run in debug mode in VSCode using the E2E launch.json and it should be good to go. If someone can confirm it works that would be good. Added to gitignore for obvious reasons, accidental pushing of local debugging etc