### PR TITLE
feat: add manifest v3 keep alive

### DIFF
--- a/lib/mv3-keep-alive.js
+++ b/lib/mv3-keep-alive.js
@@ -1,0 +1,62 @@
+const runtime = globalThis.browser?.runtime ?? globalThis.chrome?.runtime
+const isManifestV3 = runtime.getManifest().manifest_version === 3
+
+/**
+ * Initialise a keep-alive loop for manifest v3 extensions. For any other manifest version, a noop is returned,
+ * duck typing to the same function signature.
+ *
+ * @param {number} [sleep=45 * 60 * 1000] - The number of milliseconds to wait before stopping the keep-alive loop.
+ * @param {number} [ping=1000] - The number of milliseconds to wait between keep-alive heartbeats.
+ * @returns {function} - A function to call to keep the extension alive, by resetting the sleep timeout.
+ */
+export default function init(sleep = 45 * 60 * 1000, ping = 1000) {
+  // Only applicable to manifest v3 (ie chromium based browsers)
+  // Other browsers will get a noop
+  if (isManifestV3 === false) return (() => { })
+
+  // This timeout stops the keepAliveInterval. This will effectively
+  // put the extension to sleep after N minutes of inactivity.
+  let keepAliveTimeout
+
+  // This interval sends a ping to the port every M seconds to
+  // prevent the extension from going to sleep.
+  let keepAliveInterval
+
+  // Start the loop. This code is strongly inspired by Metamask's
+  // implementation: https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/contentscript.js#L133
+
+  /**
+   * Reset the sleep and ping timeouts. You should call this function each time you interact with the 
+   * extension in any way that the user expects it to be kept alive. Eg. when sending user initiated messages,
+   * when interacting with UI, etc.
+   *
+   * @param {MessagePort} port - The port to send the ping to. If null, the keep-alive loop will be stopped.
+   * @returns {void}
+   */
+  return function keepAlive(port) {
+    // Refresh the keepalive timeout
+    clearTimeout(keepAliveTimeout)
+    // Restart the keepalive interval
+    clearInterval(keepAliveInterval)
+
+    // If the port is null, we cannot send a ping, so stop here
+    if (port == null) return
+
+    keepAliveTimeout = setTimeout(() => {
+      clearInterval(keepAliveInterval)
+      keepAliveInterval = null
+      keepAliveTimeout = null
+    }, sleep)
+
+    keepAliveInterval = setInterval(() => {
+      try {
+        port.postMessage({ jsonrpc: '2.0', method: 'ping', params: null })
+      } catch (error) {
+        // The port is disconnected, stop timers
+        clearInterval(keepAliveInterval)
+        clearTimeout(keepAliveTimeout)
+      }
+    }, ping)
+  }
+}
+

--- a/web-extension/content-script.js
+++ b/web-extension/content-script.js
@@ -16,6 +16,44 @@ let backgroundPort
 
 window.addEventListener('message', onwindowmessage, false)
 
+const isManifestV3 = runtime.getManifest().manifest_version === 3
+
+// This timeout stops the keepAliveInterval. This will effectively
+// put the extension to sleep after 45 minutes of inactivity.
+let keepAliveTimeout
+
+// This interval sends a ping to the background every second to
+// prevent the extension from going to sleep.
+let keepAliveInterval
+
+// Start the loop. This code is strongly inspired by Metamask's
+// implementation: https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/contentscript.js#L133
+keepAlive()
+function keepAlive() {
+  // Only applicable to manifest v3 (ie chromium based browsers)
+  if (isManifestV3) return
+
+  // Refresh the keepalive timeout
+  clearTimeout(keepAliveTimeout)
+  keepAliveTimeout = setTimeout(() => {
+    clearInterval(keepAliveInterval)
+    keepAliveInterval = null
+    keepAliveTimeout = null
+  }, 1000 * 60 * 45)
+
+  if (keepAliveInterval != null) return
+  keepAliveInterval = setInterval(() => {
+    if (backgroundPort == null) connect()
+    backgroundPort.postMessage({ jsonrpc: '2.0', method: 'ping', params: null })
+  }, 1000)
+}
+
+function connect() {
+  backgroundPort = runtime.connect({ name: 'content-script' })
+  backgroundPort.onMessage.addListener(onbackgroundmessage)
+  backgroundPort.onDisconnect.addListener(onbackgrounddisconnect)
+}
+
 // Relay requests from page to background
 function onwindowmessage(event) {
   if (event.source !== window) return
@@ -24,12 +62,9 @@ function onwindowmessage(event) {
   // Only react to requests and notifications
   if (!isNotification(data) && !isRequest(data)) return
 
-  if (backgroundPort == null) {
-    backgroundPort = runtime.connect({ name: 'content-script' })
-    backgroundPort.onMessage.addListener(onbackgroundmessage)
-    backgroundPort.onDisconnect.addListener(onbackgrounddisconnect)
-  }
+  if (backgroundPort == null) connect()
 
+  keepAlive() // refresh keepalive on each message
   backgroundPort.postMessage(data)
 }
 

--- a/web-extension/content-script.js
+++ b/web-extension/content-script.js
@@ -1,4 +1,5 @@
 import { isRequest, isNotification } from '../lib/json-rpc.js'
+import createKeepAlive from '../lib/mv3-keep-alive.js'
 
 const runtime = globalThis.browser?.runtime ?? globalThis.chrome?.runtime
 
@@ -16,37 +17,7 @@ let backgroundPort
 
 window.addEventListener('message', onwindowmessage, false)
 
-const isManifestV3 = runtime.getManifest().manifest_version === 3
-
-// This timeout stops the keepAliveInterval. This will effectively
-// put the extension to sleep after 45 minutes of inactivity.
-let keepAliveTimeout
-
-// This interval sends a ping to the background every second to
-// prevent the extension from going to sleep.
-let keepAliveInterval
-
-// Start the loop. This code is strongly inspired by Metamask's
-// implementation: https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/contentscript.js#L133
-keepAlive()
-function keepAlive() {
-  // Only applicable to manifest v3 (ie chromium based browsers)
-  if (isManifestV3) return
-
-  // Refresh the keepalive timeout
-  clearTimeout(keepAliveTimeout)
-  keepAliveTimeout = setTimeout(() => {
-    clearInterval(keepAliveInterval)
-    keepAliveInterval = null
-    keepAliveTimeout = null
-  }, 1000 * 60 * 45)
-
-  if (keepAliveInterval != null) return
-  keepAliveInterval = setInterval(() => {
-    if (backgroundPort == null) connect()
-    backgroundPort.postMessage({ jsonrpc: '2.0', method: 'ping', params: null })
-  }, 1000)
-}
+const keepAlive = createKeepAlive()
 
 function connect() {
   backgroundPort = runtime.connect({ name: 'content-script' })
@@ -64,7 +35,9 @@ function onwindowmessage(event) {
 
   if (backgroundPort == null) connect()
 
-  keepAlive() // refresh keepalive on each message
+  // TODO: We could filter out different types of messages here like metamask does,
+  // where only user "initiated" messages cause the keep-alive loop to refresh
+  keepAlive(backgroundPort) // refresh keepalive on each message
   backgroundPort.postMessage(data)
 }
 
@@ -77,4 +50,5 @@ function onbackgrounddisconnect() {
   backgroundPort.onMessage.removeListener(onbackgroundmessage)
   backgroundPort.onDisconnect.removeListener(onbackgrounddisconnect)
   backgroundPort = null
+  keepAlive(null) // stop keepalive
 }

--- a/web-extension/test/mv3-keep-alive.spec.js
+++ b/web-extension/test/mv3-keep-alive.spec.js
@@ -1,0 +1,84 @@
+// Mock setup for Node.js
+if (globalThis.browser == null) {
+  globalThis.browser = {
+    runtime: {
+      getManifest: () => ({ manifest_version: 3 })
+    }
+  }
+}
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+describe('mv3-keep-alive', () => {
+  afterEach(() => {
+    // We're using a dynamic import, but modules will be cached between runs.
+    // This clears the cache
+    jest.resetModules()
+  })
+
+  test('returns noop if runtime is not manifest v3', async () => {
+    jest.spyOn(globalThis.browser.runtime, 'getManifest').mockReturnValue({ manifest_version: 2 })
+    const { default: createKeepAlive } = await import('../../lib/mv3-keep-alive.js')
+
+    // Check zero arity function (ie the noop)
+    expect(createKeepAlive()).toHaveLength(0)
+    jest.restoreAllMocks()
+  })
+
+  describe('keepAlive function', () => {
+    beforeEach(() => {
+      jest.spyOn(globalThis.browser.runtime, 'getManifest').mockReturnValue({ manifest_version: 3 })
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+    const sleep = 100
+    const ping = 20
+
+    test('null cancels timers', async () => {
+      const { default: createKeepAlive } = await import('../../lib/mv3-keep-alive.js')
+
+      const keepAlive = createKeepAlive(sleep, ping)
+      const port = { postMessage: jest.fn() }
+      keepAlive(port)
+      await wait(50)
+
+      keepAlive(null)
+      await wait(200)
+
+      expect(port.postMessage).toHaveBeenCalledTimes(2)
+    })
+
+    test('calling keepAlive keeps loop alive until sleep', async () => {
+      const { default: createKeepAlive } = await import('../../lib/mv3-keep-alive.js')
+
+      const keepAlive = createKeepAlive(sleep, ping)
+      const port = { postMessage: jest.fn() }
+      keepAlive(port)
+      await wait(25)
+      expect(port.postMessage).toHaveBeenCalled()
+
+      await wait(80)
+      keepAlive(port)
+
+      await wait(200)
+      expect(port.postMessage).toHaveBeenCalledTimes(8)
+
+      await wait(200)
+      expect(port.postMessage).toHaveBeenCalledTimes(8)
+    });
+
+    test('keepAlive stops if port is disconnected', async () => {
+      const { default: createKeepAlive } = await import('../../lib/mv3-keep-alive.js')
+
+      const keepAlive = createKeepAlive(sleep, ping)
+      const port = { postMessage: jest.fn(() => { throw new Error(); }) };
+      keepAlive(port)
+      await wait(25)
+      expect(port.postMessage).toHaveBeenCalled()
+      await wait(200)
+      expect(port.postMessage).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+


### PR DESCRIPTION
This should prevent the extension from locking after even a short while. It's strongly inspired by Metamask' approach.
By sending a JSON-RPC notification to the background script we can prevent the extension from going to sleep. After 45 min of inactivity the keep alive will stop and the extension go to sleep.