### PR TITLE
fix: do not show feedback until the user has set a password

### DIFF
--- a/frontend/routes/onboarding/create-password/create-password.spec.tsx
+++ b/frontend/routes/onboarding/create-password/create-password.spec.tsx
@@ -143,6 +143,9 @@ describe('CreatePassword', () => {
   it('should render password security feedback', async () => {
     // 1101-ONBD-037 During password creation, there is a way to understand whether the password I have created is secure or no
     renderComponent()
-    expect(screen.getByTestId(passwordFeedbackLocators.passwordFeedback)).toBeInTheDocument()
+    fireEvent.change(screen.getByTestId(passphraseInput), {
+      target: { value: 'test1234' }
+    })
+    await screen.findByTestId(passwordFeedbackLocators.passwordFeedback)
   })
 })

--- a/frontend/routes/onboarding/create-password/password-feedback.spec.tsx
+++ b/frontend/routes/onboarding/create-password/password-feedback.spec.tsx
@@ -35,7 +35,6 @@ describe('PasswordFeedback component', () => {
     const password = 'test123'
     render(<PasswordFeedback password={password} />)
 
-    // Assert that the password feedback strength bars are rendered
     const feedbackStrengthElements = screen.getAllByTestId(locators.feedbackStrength)
     expect(feedbackStrengthElements).toHaveLength(4)
     expect(feedbackStrengthElements[0]).toHaveClass('bg-vega-yellow-650')
@@ -48,11 +47,9 @@ describe('PasswordFeedback component', () => {
     const password = 'weak'
     render(<PasswordFeedback password={password} />)
 
-    // Assert that the password error feedback is rendered
     const errorElement = screen.getByTestId(locators.error)
     expect(errorElement).toBeInTheDocument()
 
-    // Assert that the error feedback text is correct
     const feedback = 'Weak password. Add more characters.'
     expect(errorElement).toHaveTextContent(feedback)
   })
@@ -61,8 +58,13 @@ describe('PasswordFeedback component', () => {
     const password = 'strong'
     render(<PasswordFeedback password={password} />)
 
-    // Assert that no password error feedback is rendered
     const errorElement = screen.queryByTestId(locators.error)
     expect(errorElement).toBeNull()
+  })
+
+  test('render nothing for an empty password', () => {
+    const { container } = render(<PasswordFeedback password={''} />)
+
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/frontend/routes/onboarding/create-password/password-feedback.tsx
+++ b/frontend/routes/onboarding/create-password/password-feedback.tsx
@@ -20,6 +20,7 @@ export const PasswordFeedback = ({ password }: { password: string }) => {
   const passwordStrength = zxcvbn(password)
   const combinedFeedback = [passwordStrength.feedback.warning, ...passwordStrength.feedback.suggestions].filter(Boolean)
   const feedback = combinedFeedback.map((s) => s.replace(/\.$/, '')).join('. ')
+  if (!password) return null
   return (
     <>
       <div data-testid={locators.passwordFeedback} className="grid grid-cols-4 gap-1 mt-1">


### PR DESCRIPTION
Do not validate password until it has been set