### PR TITLE
feat: add Browser Wallet At-Rest Encryption ADR

### DIFF
--- a/specs/adrs/browser-wallet-at-rest-encryption
+++ b/specs/adrs/browser-wallet-at-rest-encryption
@@ -1,0 +1,78 @@
+# Browser Wallet At-Rest Encryption - Architecture Decision Record (ADR)
+
+## Encryption algorithm
+
+### Change log
+
+|   Opened   | Last updated |    Status    |
+|:----------:|:------------:|:------------:|
+| 09/05/2023 |  09/05/2023  |     open     |
+
+
+### Context
+
+To ensure secure storage of browser wallet secrets (eg. private keys), we must encrypt data at rest.
+The threat model covers offline attacks (ie. evil maid). The encryption algorithm must be secure against
+data leakage and tampering. We therefore consider AEAD constructions encrypted using key derived from a 
+user supplied passphrase.
+
+### Considered options
+
+- For deriving a symmetric encryption key from a user supplied passphrase, the following KDFs have been considered:
+  - PBKDF2; This algorithm is widely available, both as a native browser API (`crypto.subtle`) and in various programming
+    runtimes. However it is not strong against GPU attacks, and is not memory hard.
+  - scrypt: This is a stronger KDF, however it is not widely available in browsers, and is not memory hard.
+  - Argon2id; This is the strongest KDF, however it is not widely available in browsers. This was the winner of the 2015 PHC,
+    and is resitant against GPU and ASIC attacks.
+- For encrypting information under a symmetric key:
+  - AES-GCM; This is a widely available AEAD construction, both as a native browser API (`crypto.subtle`) and in various
+    programming runtimes. It is also a NIST standard. However the IV/nonce is only 96-bits, making it unsafe to use random nonces.
+    It does provied integrity protection, and mixing additional data into the authentication tag (eg. parameters to the KDF).
+    As a native API, it can utilise hardware acceleration.
+  - XChacha20-Poly1305; This is the algorithm recommended by libsodium. It's an AEAD construction with a 192-bit nonce, allowing for
+    stateless, randomly generated nonces. It also provides integrity protection, and mixing additional data into the authentication
+    tag. It's not available as a native API in most programming languages nor the browser. However the implementation is small and fast
+    irrespective of hardware acceleration.
+  - AES-GCM with a synthetic nonce; This is a variant of AES-GCM where the nonce is derived from the key and plaintext. This
+    allows for stateless nonces by doing an additional hash of the key and salt. This has the same properties as AES-GCM mentioned
+    above, however requires extra care with the implementation to ensure the nonce is not reused. This is the algorithm detailed below.
+  
+
+### Decision outcome
+
+Argon2id is propsed as the KDF for deriving a symmetric key from a user supplied passphrase. This is readily available in the Rust programming
+language and can be easily compiled to WASM. It adds another 10kb gzipped to our existing WASM crypto bundle.
+
+AES-256-GCM with a synthetic nonce is proposed in the following pseudo code:
+
+```text
+fn Encrypt (passphrase, plaintext, kdfParams):
+  salt = random(16)
+  key = argon2id(passphrase, salt, kdfParams)
+
+  nonce = sha256(key, salt)
+
+  ciphertext = aesgcmEncrypt(key, nonce[0:12], plaintext, aad = kdfParams)
+
+  return salt, ciphertext
+
+fn Decrypt (passphrase, salt, kdfParams):
+  key = argon2id(passphrase, salt, kdfParams)
+
+  nonce = sha256(key, salt)
+
+  plaintext = aesgcmDecrypt(key, nonce[0:12], ciphertext, aad = kdfParams)
+
+  return plaintext
+```
+
+It should be noted that each change to the plaintext will generate a new salt that must be persisted along with the ciphertext and kdfParams.
+kdfParams include the number of iterations (5), memory size (256MB), parallelism (1), algorithms and versions.
+
+### Open risks
+
+- Unknown / TBC
+
+### Limitations
+
+- Unknown / TBC


### PR DESCRIPTION
As the spec information for the wallet is being created in this repo the decision record from the specs repo:

- https://github.com/vegaprotocol/specs/pull/1693

has been transferred over.

Should this be approved, next steps would be:

- [ ] close the PR in the specs repo
- [ ] update relevant wallet specs in the [specs repo](https://github.com/vegaprotocol/specs) with a link to the [browser wallet specs](https://github.com/vegaprotocol/vegawallet-browser/tree/main/specs) directory in this repo