### PR TITLE
chore: add description to manifest

### DIFF
--- a/manifests/common.json
+++ b/manifests/common.json
@@ -8,7 +8,6 @@
     "96": "__ICON_PREFIX__-96x96.png",
     "128": "__ICON_PREFIX__-128x128.png"
   },
-  "default_locale": "en",
   "description": "Vega web wallet",
   "permissions": ["storage"],
   "content_scripts": [

--- a/manifests/common.json
+++ b/manifests/common.json
@@ -8,17 +8,13 @@
     "96": "__ICON_PREFIX__-96x96.png",
     "128": "__ICON_PREFIX__-128x128.png"
   },
-  "permissions": [
-    "storage"
-  ],
+  "default_locale": "en",
+  "description": "Vega web wallet",
+  "permissions": ["storage"],
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "./content-script.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["./content-script.js"],
       "run_at": "document_end"
     }
   ]


### PR DESCRIPTION
To prevent chrome store from adding an extra unneeded line of text.