### PR TITLE
fix: remove dodgy eval of regex

### DIFF
--- a/frontend/lib/form-validation.ts
+++ b/frontend/lib/form-validation.ts
@@ -1,9 +1,3 @@
 export const Validation = {
-  REQUIRED: 'Required',
-
-  // Custom logic
-  match: (value: string | number | boolean) => ({
-    message: 'Password does not match',
-    value: new RegExp(`^${value}$`)
-  })
+  REQUIRED: 'Required'
 }

--- a/frontend/routes/onboarding/create-password/create-password.spec.tsx
+++ b/frontend/routes/onboarding/create-password/create-password.spec.tsx
@@ -106,10 +106,10 @@ describe('CreatePassword', () => {
     renderComponent()
 
     fireEvent.change(screen.getByTestId(passphraseInput), {
-      target: { value: 'test1234' }
+      target: { value: 'te$t1234' }
     })
     fireEvent.change(screen.getByTestId(confirmPassphraseInput), {
-      target: { value: 'test1234' }
+      target: { value: 'te$t1234' }
     })
 
     const checkbox = screen.getByLabelText('I understand that Vega Wallet cannot recover this password if I lose it')
@@ -126,10 +126,10 @@ describe('CreatePassword', () => {
     renderComponent()
 
     fireEvent.change(screen.getByTestId(passphraseInput), {
-      target: { value: 'test1234' }
+      target: { value: 'te$t1234' }
     })
     fireEvent.change(screen.getByTestId(confirmPassphraseInput), {
-      target: { value: 'test1234' }
+      target: { value: 'te$t1234' }
     })
 
     const checkbox = screen.getByLabelText('I understand that Vega Wallet cannot recover this password if I lose it')
@@ -144,7 +144,7 @@ describe('CreatePassword', () => {
     // 1101-ONBD-036 During password creation, there is a way to understand whether the password I have created is secure or no
     renderComponent()
     fireEvent.change(screen.getByTestId(passphraseInput), {
-      target: { value: 'test1234' }
+      target: { value: 'te$t1234' }
     })
     await screen.findByTestId(passwordFeedbackLocators.passwordFeedback)
   })

--- a/frontend/routes/onboarding/create-password/create-password.spec.tsx
+++ b/frontend/routes/onboarding/create-password/create-password.spec.tsx
@@ -98,7 +98,7 @@ describe('CreatePassword', () => {
 
     fireEvent.click(screen.getByTestId(submitPassphraseButton))
 
-    expect(await screen.findByText('Password does not match')).toBeInTheDocument()
+    expect(await screen.findByText('Passwords do not match')).toBeInTheDocument()
   })
 
   it('should render loading state once the create button is pressed', async () => {

--- a/frontend/routes/onboarding/create-password/create-password.tsx
+++ b/frontend/routes/onboarding/create-password/create-password.tsx
@@ -73,7 +73,7 @@ export const CreatePassword = () => {
               type="password"
               {...register('confirmPassword', {
                 required: Validation.REQUIRED,
-                pattern: Validation.match(password)
+                validate: (val) => val === password || 'Passwords do not match'
               })}
             />
             {errors.confirmPassword?.message && (

--- a/test/e2e/onboarding.spec.ts
+++ b/test/e2e/onboarding.spec.ts
@@ -100,7 +100,7 @@ describe('Onboarding', () => {
 
   it('shows an error message when passwords differ', async () => {
     await password.createPassword(defaultPassword, defaultPassword + '2')
-    expect(await password.getErrorMessageText()).toBe('Password does not match')
+    expect(await password.getErrorMessageText()).toBe('Passwords do not match')
     await password.checkOnCreatePasswordPage()
   })
 


### PR DESCRIPTION
Related to #512 

Allow special characters in passwords

Validation was done by casting to RegEx which is unsecure and errored when a regex special character was inserted. Chnage to simple equality check.