### PR TITLE
feat: pegged order reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea
+/.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/frontend/components/receipts/orders/submission/index.tsx
+++ b/frontend/components/receipts/orders/submission/index.tsx
@@ -6,7 +6,7 @@ import { ReceiptWrapper } from '../../utils/receipt-wrapper'
 export const Submission = ({ transaction }: ReceiptComponentProps) => {
   const submission = transaction.orderSubmission
 
-  if (submission.peggedOrder || submission.icebergOpts) return null
+  if (submission.icebergOpts) return null
   return (
     <ReceiptWrapper>
       <OrderTable {...submission} />

--- a/frontend/components/receipts/orders/submission/submission.spec.tsx
+++ b/frontend/components/receipts/orders/submission/submission.spec.tsx
@@ -3,18 +3,6 @@ import { Submission } from '.'
 import { locators } from '../../../data-table/data-table'
 
 describe('SubmissionReceipt', () => {
-  it('renders nothing if the transaction is a pegged order', () => {
-    const { container } = render(
-      <Submission
-        transaction={{
-          orderSubmission: {
-            peggedOrder: {}
-          }
-        }}
-      />
-    )
-    expect(container).toBeEmptyDOMElement()
-  })
   it('renders nothing if the transaction is an iceberg order', () => {
     const { container } = render(
       <Submission

--- a/frontend/components/receipts/utils/order-table.spec.tsx
+++ b/frontend/components/receipts/utils/order-table.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { OrderTable } from './order-table'
 import { locators } from '../../data-table/data-table'
-import { OrderType, Side } from '@vegaprotocol/types'
+import { OrderType, PeggedReference, Side } from '@vegaprotocol/types'
 
 describe('OrderTable', () => {
   it('renders a row for each property', () => {
@@ -16,6 +16,8 @@ describe('OrderTable', () => {
     // 1114-RCPT-020 If present I can see the order id relating to the order
     // 1114-RCPT-021 I can see the order id of the order I am amending
     // 1114-RCPT-022 I can see the market id relating to the order I am amending
+    // 1114-RCPT-026 I can see the offset price of a pegged order
+    // 1114-RCPT-027 I can see the reference value of a peg
     render(
       <OrderTable
         direction={Side.SIDE_BUY}
@@ -25,13 +27,19 @@ describe('OrderTable', () => {
         price={'123'}
         reference="ref"
         type={OrderType.TYPE_MARKET}
+        peggedOrder={{
+          reference: PeggedReference.PEGGED_REFERENCE_BEST_BID,
+          offset: '6'
+        }}
       />
     )
-    const [priceRow, sizeRow, marketRow, orderRow, directionRow, typeRow, referenceRow] = screen.getAllByTestId(
-      locators.dataRow
-    )
+    const [priceRow, peggedInfoRow, sizeRow, marketRow, orderRow, directionRow, typeRow, referenceRow] =
+      screen.getAllByTestId(locators.dataRow)
     expect(priceRow).toHaveTextContent('Price')
     expect(priceRow).toHaveTextContent('123')
+
+    expect(peggedInfoRow).toHaveTextContent('6')
+    expect(peggedInfoRow).toHaveTextContent('from best bid')
 
     expect(sizeRow).toHaveTextContent('Size')
     expect(sizeRow).toHaveTextContent('12')
@@ -50,7 +58,7 @@ describe('OrderTable', () => {
 
     expect(referenceRow).toHaveTextContent('Reference')
     expect(referenceRow).toHaveTextContent('ref')
-    expect(screen.getAllByTestId(locators.dataRow)).toHaveLength(7)
+    expect(screen.getAllByTestId(locators.dataRow)).toHaveLength(8)
   })
 
   it('does not render row if the property is undefined', () => {

--- a/frontend/components/receipts/utils/order-table.tsx
+++ b/frontend/components/receipts/utils/order-table.tsx
@@ -1,10 +1,11 @@
 import { ReactNode } from 'react'
 import { DataTable } from '../../data-table/data-table'
 import { truncateMiddle } from '@vegaprotocol/ui-toolkit'
-import { OrderType, Side } from '@vegaprotocol/types'
+import { OrderType, Side, PeggedOrder } from '@vegaprotocol/types'
 import { MarketLink } from './order/market-link'
 import { Direction } from './order/direction'
 import { OrderTypeComponent } from './order/order-type'
+import { PeggedOrderInfo } from './order/pegged-order-info.tsx'
 import { PriceWithTooltip } from './string-amounts/price-with-tooltip'
 import { SizeWithTooltip } from './string-amounts/size-with-tooltip'
 
@@ -15,7 +16,8 @@ export const OrderTable = ({
   reference,
   price,
   size,
-  type
+  type,
+  peggedOrder
 }: Partial<{
   marketId: string
   orderId: string
@@ -24,10 +26,14 @@ export const OrderTable = ({
   price: string
   reference: string
   type: OrderType
+  peggedOrder?: PeggedOrder
 }>) => {
   const columns = [
-    price && marketId
+    price && price !== '0' && marketId
       ? ['Price', <PriceWithTooltip key="order-details-price" marketId={marketId} price={price} />]
+      : null,
+    peggedOrder && marketId
+      ? ['Price', <PeggedOrderInfo key="order-details-pegged" peggedOrder={peggedOrder} marketId={marketId} />]
       : null,
     size && marketId ? ['Size', <SizeWithTooltip key="order-details-price" marketId={marketId} size={size} />] : null,
     marketId ? ['Market', <MarketLink key="order-details-market" marketId={marketId} />] : null,

--- a/frontend/components/receipts/utils/order-table.tsx
+++ b/frontend/components/receipts/utils/order-table.tsx
@@ -33,7 +33,7 @@ export const OrderTable = ({
       ? ['Price', <PriceWithTooltip key="order-details-price" marketId={marketId} price={price} />]
       : null,
     peggedOrder && marketId
-      ? ['Price', <PeggedOrderInfo key="order-details-pegged" peggedOrder={peggedOrder} marketId={marketId} />]
+      ? ['Pegged price', <PeggedOrderInfo key="order-details-pegged" peggedOrder={peggedOrder} marketId={marketId} />]
       : null,
     size && marketId ? ['Size', <SizeWithTooltip key="order-details-price" marketId={marketId} size={size} />] : null,
     marketId ? ['Market', <MarketLink key="order-details-market" marketId={marketId} />] : null,

--- a/frontend/components/receipts/utils/order/pegged-order-info.spec.tsx
+++ b/frontend/components/receipts/utils/order/pegged-order-info.spec.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { PeggedOrderInfo } from './pegged-order-info'
+import { PeggedOrder, PeggedReference } from '@vegaprotocol/types'
+
+describe('PeggedOrderInfo', () => {
+  // 1114-RCPT-026 I can see the offset price
+  // 1114-RCPT-027 I can see the reference price
+  const marketId = 'someMarketId'
+
+  it('should render without crashing', () => {
+    const peggedOrder: PeggedOrder = {
+      offset: '12',
+      reference: PeggedReference.PEGGED_REFERENCE_BEST_BID
+    }
+    render(<PeggedOrderInfo peggedOrder={peggedOrder} marketId={marketId} />)
+    expect(screen.getByTestId('price-with-tooltip')).toBeInTheDocument()
+  })
+
+  it('should display the offset price correctly', () => {
+    const peggedOrder: PeggedOrder = {
+      offset: '12',
+      reference: PeggedReference.PEGGED_REFERENCE_BEST_BID
+    }
+    render(<PeggedOrderInfo peggedOrder={peggedOrder} marketId={marketId} />)
+    expect(screen.getByText('12')).toBeInTheDocument()
+  })
+
+  it('should format and display the reference price correctly', () => {
+    const peggedOrder: PeggedOrder = {
+      offset: '12',
+      reference: PeggedReference.PEGGED_REFERENCE_BEST_BID
+    }
+    render(<PeggedOrderInfo peggedOrder={peggedOrder} marketId={marketId} />)
+    expect(screen.getByText('from best bid')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/receipts/utils/order/pegged-order-info.spec.tsx
+++ b/frontend/components/receipts/utils/order/pegged-order-info.spec.tsx
@@ -25,12 +25,20 @@ describe('PeggedOrderInfo', () => {
     expect(screen.getByText('12')).toBeInTheDocument()
   })
 
-  it('should format and display the reference price correctly', () => {
-    const peggedOrder: PeggedOrder = {
-      offset: '12',
-      reference: PeggedReference.PEGGED_REFERENCE_BEST_BID
+  it('should display PeggedReference values correctly', () => {
+    const testCases = [
+      { reference: PeggedReference.PEGGED_REFERENCE_BEST_BID, expectedText: 'from best bid' },
+      { reference: PeggedReference.PEGGED_REFERENCE_BEST_ASK, expectedText: 'from best ask' },
+      { reference: PeggedReference.PEGGED_REFERENCE_MID, expectedText: 'from mid' }
+    ]
+
+    for (const { reference, expectedText } of testCases) {
+      const peggedOrder: PeggedOrder = {
+        offset: '12',
+        reference
+      }
+      render(<PeggedOrderInfo peggedOrder={peggedOrder} marketId={marketId} />)
+      expect(screen.getByText(expectedText)).toBeInTheDocument()
     }
-    render(<PeggedOrderInfo peggedOrder={peggedOrder} marketId={marketId} />)
-    expect(screen.getByText('from best bid')).toBeInTheDocument()
   })
 })

--- a/frontend/components/receipts/utils/order/pegged-order-info.tsx
+++ b/frontend/components/receipts/utils/order/pegged-order-info.tsx
@@ -1,5 +1,11 @@
 import { PriceWithTooltip } from '../string-amounts/price-with-tooltip.tsx'
-import { PeggedOrder } from '@vegaprotocol/types'
+import { PeggedOrder, PeggedReference } from '@vegaprotocol/types'
+
+export const referenceText: Record<PeggedReference, string> = {
+  PEGGED_REFERENCE_BEST_ASK: 'best ask',
+  PEGGED_REFERENCE_BEST_BID: 'best bid',
+  PEGGED_REFERENCE_MID: 'mid'
+}
 
 interface PeggedOrderInfoProps {
   peggedOrder: PeggedOrder
@@ -8,12 +14,11 @@ interface PeggedOrderInfoProps {
 
 export const PeggedOrderInfo = ({ peggedOrder, marketId }: PeggedOrderInfoProps) => {
   const { offset, reference } = peggedOrder
-  const formattedReference = reference.toLowerCase().replace('pegged_reference_', '').replace('_', ' ')
 
   return (
     <span className="flex items-center">
       <PriceWithTooltip price={offset} marketId={marketId} />{' '}
-      <span className="pl-1 text-vega-dark-400">from {formattedReference}</span>
+      <span className="pl-1 text-vega-dark-400">from {referenceText[reference]}</span>
     </span>
   )
 }

--- a/frontend/components/receipts/utils/order/pegged-order-info.tsx
+++ b/frontend/components/receipts/utils/order/pegged-order-info.tsx
@@ -1,0 +1,19 @@
+import { PriceWithTooltip } from '../string-amounts/price-with-tooltip.tsx'
+import { PeggedOrder } from '@vegaprotocol/types'
+
+interface PeggedOrderInfoProps {
+  peggedOrder: PeggedOrder
+  marketId: string
+}
+
+export const PeggedOrderInfo = ({ peggedOrder, marketId }: PeggedOrderInfoProps) => {
+  const { offset, reference } = peggedOrder
+  const formattedReference = reference.toLowerCase().replace('pegged_reference_', '').replace('_', ' ')
+
+  return (
+    <span className="flex items-center">
+      <PriceWithTooltip price={offset} marketId={marketId} />{' '}
+      <span className="pl-1 text-vega-dark-400">from {formattedReference}</span>
+    </span>
+  )
+}

--- a/specs/1114-RCPT-receipt_views.md
+++ b/specs/1114-RCPT-receipt_views.md
@@ -1,31 +1,43 @@
 ## Receipt views
 
-As a user I want to understand my transaction so that I can know what I am sending to the network. e.g. price is based on the asset or position decimals which can make this look inflated or incorrect if I do not understand the internals of Vega.
+As a user I want to understand my transaction so that I can know what I am sending to the network. e.g. price is based
+on the asset or position decimals which can make this look inflated or incorrect if I do not understand the internals of
+Vega.
 
 ## Shared
 
-- I can see a receipt like view on the transaction confirmation screen if one is present (<a name="1114-RCPT-001" href="#1114-RCPT-001">1114-RCPT-001</a>)
-- I see a loading state while the enrichment data is loading (<a name="1114-RCPT-002" href="#1114-RCPT-002">1114-RCPT-002</a>)
-- If there is an error loading the data I see an indication of it (<a name="1114-RCPT-003" href="#1114-RCPT-003">1114-RCPT-003</a>)
+- I can see a receipt like view on the transaction confirmation screen if one is
+  present (<a name="1114-RCPT-001" href="#1114-RCPT-001">1114-RCPT-001</a>)
+- I see a loading state while the enrichment data is loading (<a name="1114-RCPT-002" href="#1114-RCPT-002">
+  1114-RCPT-002</a>)
+- If there is an error loading the data I see an indication of it (<a name="1114-RCPT-003" href="#1114-RCPT-003">
+  1114-RCPT-003</a>)
 
 ## Transfer
 
 ### One off Transfers
 
 - I can see the receiving key of the transfer (<a name="1114-RCPT-004" href="#1114-RCPT-004">1114-RCPT-004</a>)
-- For a oneOff transfer which has a delivery date in the past there is a way to see that the transfer will be executed immediately (<a name="1114-RCPT-005" href="#1114-RCPT-005">1114-RCPT-005</a>)
-- For a oneOff transfer which has a delivery date in the future there is a way to see when the transfer will be delivered (<a name="1114-RCPT-006" href="#1114-RCPT-006">1114-RCPT-006</a>)
+- For a oneOff transfer which has a delivery date in the past there is a way to see that the transfer will be executed
+  immediately (<a name="1114-RCPT-005" href="#1114-RCPT-005">1114-RCPT-005</a>)
+- For a oneOff transfer which has a delivery date in the future there is a way to see when the transfer will be
+  delivered (<a name="1114-RCPT-006" href="#1114-RCPT-006">1114-RCPT-006</a>)
 - I can see the amount of the asset being transferred (<a name="1114-RCPT-007" href="#1114-RCPT-007">1114-RCPT-007</a>)
-- I can see a link to the block explorer for that asset (<a name="1114-RCPT-008" href="#1114-RCPT-008">1114-RCPT-008</a>)
-- When I hover over the price I can see an explanation of how to calculate the human readable price from the raw price (<a name="1114-RCPT-009" href="#1114-RCPT-009">1114-RCPT-009</a>)
-- When I hover over the price I can see a link to the docs to read more about the price (<a name="1114-RCPT-010" href="#1114-RCPT-010">1114-RCPT-010</a>)
-- When I hover over the price I can click on a link to go to the block explorer to see the asset information (<a name="1114-RCPT-011" href="#1114-RCPT-011">1114-RCPT-011</a>)
+- I can see a link to the block explorer for that asset (<a name="1114-RCPT-008" href="#1114-RCPT-008">
+  1114-RCPT-008</a>)
+- When I hover over the price I can see an explanation of how to calculate the human readable price from the raw
+  price (<a name="1114-RCPT-009" href="#1114-RCPT-009">1114-RCPT-009</a>)
+- When I hover over the price I can see a link to the docs to read more about the
+  price (<a name="1114-RCPT-010" href="#1114-RCPT-010">1114-RCPT-010</a>)
+- When I hover over the price I can click on a link to go to the block explorer to see the asset
+  information (<a name="1114-RCPT-011" href="#1114-RCPT-011">1114-RCPT-011</a>)
 
 <!-- Recurring transfers not currently supported -->
 
 ## Withdrawal
 
-- I can see the Ethereum key I am withdrawing the assets to (<a name="1114-RCPT-007" href="#1114-RCPT-007">1114-RCPT-007</a>)
+- I can see the Ethereum key I am withdrawing the assets to (<a name="1114-RCPT-007" href="#1114-RCPT-007">
+  1114-RCPT-007</a>)
 
 ## Order
 
@@ -36,7 +48,8 @@ As a user I want to understand my transaction so that I can know what I am sendi
 - I can see a badge if the order is post only (<a name="1114-RCPT-008" href="#1114-RCPT-008">1114-RCPT-008</a>)
 - I can see a badge if the order is reduce only (<a name="1114-RCPT-009" href="#1114-RCPT-009">1114-RCPT-009</a>)
 - I can see a badge of the order time in force (<a name="1114-RCPT-010" href="#1114-RCPT-010">1114-RCPT-010</a>)
-- If time in force is GTT then I can see the expiry of the order (<a name="1114-RCPT-011" href="#1114-RCPT-011">1114-RCPT-011</a>)
+- If time in force is GTT then I can see the expiry of the order (<a name="1114-RCPT-011" href="#1114-RCPT-011">
+  1114-RCPT-011</a>)
 
 <!-- #### Data enrichment -->
 
@@ -52,16 +65,27 @@ As a user I want to understand my transaction so that I can know what I am sendi
 
 ### Order cancellation
 
-- If present I can see the market id relating to the order (<a name="1114-RCPT-019" href="#1114-RCPT-019">1114-RCPT-019</a>)
-- If present I can see the order id relating to the order (<a name="1114-RCPT-020" href="#1114-RCPT-020">1114-RCPT-020</a>)
+- If present I can see the market id relating to the order (<a name="1114-RCPT-019" href="#1114-RCPT-019">
+  1114-RCPT-019</a>)
+- If present I can see the order id relating to the order (<a name="1114-RCPT-020" href="#1114-RCPT-020">
+  1114-RCPT-020</a>)
 
 ### Order amendment
 
 - I can see the order id of the order I am amending (<a name="1114-RCPT-021" href="#1114-RCPT-021">1114-RCPT-021</a>)
-- I can see the market id relating to the order I am amending (<a name="1114-RCPT-022" href="#1114-RCPT-022">1114-RCPT-022</a>)
+- I can see the market id relating to the order I am amending (<a name="1114-RCPT-022" href="#1114-RCPT-022">
+  1114-RCPT-022</a>)
 - I can see any relevant [order badges](#order-badges) (<a name="1114-RCPT-023" href="#1114-RCPT-023">1114-RCPT-023</a>)
 
 ### Decimal numbers
 
-- I can see a tooltip for how to add the decimals to the number (<a name="1114-RCPT-024" href="#1114-RCPT-024">1114-RCPT-024</a>)
-- I can see a link in the tooltip to the relevant entity on the block explorer (<a name="1114-RCPT-025" href="#1114-RCPT-025">1114-RCPT-025</a>)
+- I can see a tooltip for how to add the decimals to the number (<a name="1114-RCPT-024" href="#1114-RCPT-024">
+  1114-RCPT-024</a>)
+- I can see a link in the tooltip to the relevant entity on the block
+  explorer (<a name="1114-RCPT-025" href="#1114-RCPT-025">1114-RCPT-025</a>)
+
+### Pegged Orders
+
+- I can see the offset price (<a name="1114-RCPT-026" href="#1114-RCPT-026">1114-RCPT-026</a>)
+- I can see the reference price (<a name="1114-RCPT-027" href="#1114-RCPT-027">1114-RCPT-027</a>)
+


### PR DESCRIPTION
Provides pegged order details in order submissions.

<img width="357" alt="Screenshot 2023-09-12 at 16 20 49" src="https://github.com/vegaprotocol/vegawallet-browser/assets/2410498/16908a14-0301-4ae7-9681-1aa1d5458cf9">
