### PR TITLE
test: fix flakey test

### DIFF
--- a/frontend/routes/onboarding/create-password/create-password.spec.tsx
+++ b/frontend/routes/onboarding/create-password/create-password.spec.tsx
@@ -116,10 +116,8 @@ describe('CreatePassword', () => {
     fireEvent.click(checkbox)
     expect(checkbox).toBeChecked()
     fireEvent.click(screen.getByTestId(locators.submitPassphraseButton))
-    await waitFor(() =>
-      expect(screen.getByTestId(locators.submitPassphraseButton)).toHaveTextContent('Creating password…')
-    )
     await waitFor(() => expect(screen.getByTestId(locators.submitPassphraseButton)).toBeDisabled())
+    expect(screen.getByTestId(locators.submitPassphraseButton)).toHaveTextContent('Creating password…')
   })
 
   it('should navigate to create wallet page when form is submitted with valid data', async () => {


### PR DESCRIPTION
Test was flaking due to double waitFor which was pushing the second assertion onto the event queue. Removing the second await should exectue in sequence in the event queue and prevent the flake from resurfacing