### PR TITLE
hack: load wallets faster

### DIFF
--- a/frontend/routes/auth/index.tsx
+++ b/frontend/routes/auth/index.tsx
@@ -34,6 +34,7 @@ export const Auth = () => {
     loadWallets(request)
   }, [request, loadWallets])
 
+  // TODO: Remove
   // HACK: This is work around to ensure that the wallets are loaded before network requests.
   // Ideally the backend should be capable of doing this in parallel, but increases perceived performance for now.
   useEffect(() => {

--- a/frontend/routes/auth/index.tsx
+++ b/frontend/routes/auth/index.tsx
@@ -15,8 +15,9 @@ export const Auth = () => {
   const { request } = useJsonRpcClient()
 
   // Wallets store
-  const { loadWallets } = useWalletStore((state) => ({
-    loadWallets: state.loadWallets
+  const { loadWallets, loading } = useWalletStore((state) => ({
+    loadWallets: state.loadWallets,
+    loading: state.loading
   }))
 
   // Assets store
@@ -31,9 +32,16 @@ export const Auth = () => {
 
   useEffect(() => {
     loadWallets(request)
-    loadAssets(request)
-    loadMarkets(request)
-  }, [request, loadWallets, loadAssets, loadMarkets])
+  }, [request, loadWallets])
+
+  // HACK: This is work around to ensure that the wallets are loaded before network requests.
+  // Ideally the backend should be capable of doing this in parallel, but increases perceived performance for now.
+  useEffect(() => {
+    if (!loading) {
+      loadAssets(request)
+      loadMarkets(request)
+    }
+  }, [loadAssets, loadMarkets, loading, request])
 
   const isWallets = !!useMatch(FULL_ROUTES.wallets)
 


### PR DESCRIPTION
Related to #575 

A hack around the backend not doing requests in parallel to increase perceived performance in the short term.