### PR TITLE
test: handle the driver crashing because it does not like auto close

### DIFF
--- a/test/console-smoke/console-smoke.spec.ts
+++ b/test/console-smoke/console-smoke.spec.ts
@@ -28,6 +28,7 @@ let approveTransaction: boolean
 let market: string
 let config: any
 let acceptRisk: boolean
+const maxRetries = 3
 
 beforeEach(async () => {
   driver = await initDriver()
@@ -96,5 +97,5 @@ it('check console and browser wallet integrate', async () => {
       await transaction.rejectTransaction()
       await switchWindowHandles(driver, false)
     }
-  }, 0)
+  })
 })

--- a/test/console-smoke/console-smoke.spec.ts
+++ b/test/console-smoke/console-smoke.spec.ts
@@ -1,7 +1,12 @@
 import { WebDriver } from 'selenium-webdriver'
 import { ConnectWallet } from '../e2e/page-objects/connect-wallet'
 import { APIHelper } from '../e2e/helpers/wallet/wallet-api'
-import { captureScreenshot, initDriver, isDriverInstanceClosed } from '../e2e/helpers/driver'
+import {
+  captureScreenshot,
+  initDriver,
+  isDriverInstanceClosed,
+  runTestRetryIfDriverCrashes
+} from '../e2e/helpers/driver'
 import { navigateToExtensionLandingPage } from '../e2e/helpers/wallet/wallet-setup'
 import { Transaction } from '../e2e/page-objects/transaction'
 import { goToNewWindowHandle, switchWindowHandles, windowHandleHasCount } from '../e2e/helpers/selenium-util'
@@ -55,39 +60,41 @@ afterEach(async () => {
 })
 
 it('check console and browser wallet integrate', async () => {
-  driver.get(config.network.console)
-  const handlesBeforeConnect = await driver.getAllWindowHandles()
-  const consoleHandle = await driver.getWindowHandle()
+  await runTestRetryIfDriverCrashes(async () => {
+    driver.get(config.network.console)
+    const handlesBeforeConnect = await driver.getAllWindowHandles()
+    const consoleHandle = await driver.getWindowHandle()
 
-  await vegaConsole.clearWelcomeDialogIfShown()
-  await vegaConsole.checkOnConsole()
-  await vegaConsole.selectMarketBySubstring(market)
-  await vegaConsole.connectToWallet()
-  expect(await windowHandleHasCount(driver, handlesBeforeConnect.length + 1)).toBe(true)
-  const handlesAfterConnect = await driver.getAllWindowHandles()
+    await vegaConsole.clearWelcomeDialogIfShown()
+    await vegaConsole.checkOnConsole()
+    await vegaConsole.selectMarketBySubstring(market)
+    await vegaConsole.connectToWallet()
+    expect(await windowHandleHasCount(driver, handlesBeforeConnect.length + 1)).toBe(true)
+    const handlesAfterConnect = await driver.getAllWindowHandles()
 
-  await goToNewWindowHandle(driver, handlesBeforeConnect, handlesAfterConnect)
-  await connectWallet.checkOnConnectWallet()
-  await connectWallet.approveConnectionAndCheckSuccess()
-  expect(await isDriverInstanceClosed(driver, consoleHandle)).toBe(true)
+    await goToNewWindowHandle(driver, handlesBeforeConnect, handlesAfterConnect)
+    await connectWallet.checkOnConnectWallet()
+    await connectWallet.approveConnectionAndCheckSuccess()
+    expect(await isDriverInstanceClosed(driver, consoleHandle)).toBe(true)
 
-  expect(await windowHandleHasCount(driver, handlesBeforeConnect.length)).toBe(true)
-  if (acceptRisk) {
-    await vegaConsole.agreeToUnderstandRisk()
-  }
-  await vegaConsole.waitForConnectDialogToDissapear()
-  const handlesBeforeOrder = await driver.getAllWindowHandles()
-  await vegaConsole.goToOrderTab()
-  await vegaConsole.submitOrder('0.001', '0.01')
-  expect(await windowHandleHasCount(driver, handlesBeforeConnect.length + 1)).toBe(true)
-  const handlesAfterOrder = await driver.getAllWindowHandles()
-  await goToNewWindowHandle(driver, handlesBeforeOrder, handlesAfterOrder)
-  if (approveTransaction) {
-    await transaction.confirmTransaction()
-    await switchWindowHandles(driver, false)
-    await vegaConsole.checkTransactionSuccess()
-  } else {
-    await transaction.rejectTransaction()
-    await switchWindowHandles(driver, false)
-  }
+    expect(await windowHandleHasCount(driver, handlesBeforeConnect.length)).toBe(true)
+    if (acceptRisk) {
+      await vegaConsole.agreeToUnderstandRisk()
+    }
+    await vegaConsole.waitForConnectDialogToDissapear()
+    const handlesBeforeOrder = await driver.getAllWindowHandles()
+    await vegaConsole.goToOrderTab()
+    await vegaConsole.submitOrder('0.001', '0.01')
+    expect(await windowHandleHasCount(driver, handlesBeforeConnect.length + 1)).toBe(true)
+    const handlesAfterOrder = await driver.getAllWindowHandles()
+    await goToNewWindowHandle(driver, handlesBeforeOrder, handlesAfterOrder)
+    if (approveTransaction) {
+      await transaction.confirmTransaction()
+      await switchWindowHandles(driver, false)
+      await vegaConsole.checkTransactionSuccess()
+    } else {
+      await transaction.rejectTransaction()
+      await switchWindowHandles(driver, false)
+    }
+  }, 0)
 })

--- a/test/e2e/helpers/driver.ts
+++ b/test/e2e/helpers/driver.ts
@@ -117,16 +117,17 @@ export async function isDriverInstanceClosed(driver: WebDriver, handleToSwitchBa
 
 // This is not something we want to do. We should ONLY use this on ECONNREFUSED exceptions in tests that use the popout functionality, not to accommodate for UI flakiness.
 // This is because selenium randomly crashes due to our auto open/close functionality, however we still want to test it.
-export async function runTestRetryIfDriverCrashes(testFunction: () => Promise<void>, retries: number) {
+export async function runTestRetryIfDriverCrashes(testFunction: () => Promise<void>, maxRetries = 3) {
+  let retries = 0
   try {
     await testFunction()
   } catch (error) {
-    if ((error as Error).message.includes('ECONNREFUSED') && retries < 3) {
-      console.warn(`Test failed with ECONNREFUSED. Retrying (${retries + 1} of ${3})...`)
+    if ((error as Error).message.includes('ECONNREFUSED') && retries < maxRetries) {
+      console.warn(`Test failed with ECONNREFUSED. Retrying (${retries + 1} of ${maxRetries})...`)
       await runTestRetryIfDriverCrashes(testFunction, retries + 1)
     } else {
       if (retries == 3) {
-        console.log('driver crashed three times in a row. Failing the test. Investigate your configution')
+        console.log('driver crashed three times in a row. Failing the test. Investigate your configuration')
       }
       throw error
     }

--- a/test/e2e/helpers/driver.ts
+++ b/test/e2e/helpers/driver.ts
@@ -126,7 +126,7 @@ export async function runTestRetryIfDriverCrashes(testFunction: () => Promise<vo
       console.warn(`Test failed with ECONNREFUSED. Retrying (${retries + 1} of ${maxRetries})...`)
       await runTestRetryIfDriverCrashes(testFunction, retries + 1)
     } else {
-      if (retries == 3) {
+      if (retries == maxRetries) {
         console.log('driver crashed three times in a row. Failing the test. Investigate your configuration')
       }
       throw error

--- a/test/e2e/popout.spec.ts
+++ b/test/e2e/popout.spec.ts
@@ -2,7 +2,7 @@ import { WebDriver } from 'selenium-webdriver'
 import { VegaAPI } from './helpers/wallet/vega-api'
 import { ConnectWallet } from './page-objects/connect-wallet'
 import { APIHelper } from './helpers/wallet/wallet-api'
-import { captureScreenshot, initDriver, isDriverInstanceClosed } from './helpers/driver'
+import { captureScreenshot, initDriver, isDriverInstanceClosed, runTestRetryIfDriverCrashes } from './helpers/driver'
 import { dummyTransaction } from './helpers/wallet/common-wallet-values'
 import { goToNewWindowHandle, switchWindowHandles, windowHandleHasCount } from './helpers/selenium-util'
 import { Transaction } from './page-objects/transaction'
@@ -16,6 +16,7 @@ describe('check popout functionality', () => {
   let apiHelper: APIHelper
   let transaction: Transaction
   let originalHandle: string
+  const maxRetries = 3
 
   beforeEach(async () => {
     driver = await initDriver()
@@ -36,66 +37,78 @@ describe('check popout functionality', () => {
   it('connect request opens in popout and can be approved when extension not already open', async () => {
     // 1113-POPT-001 The browser wallet opens in a pop-up window when there is a connection request
     // 1113-POPT-003 If I approve the connection the pop-up window closes
-    const { handlesBeforeConnect, handlesAfterConnect } = await sendConnectionRequestAndReturnHandles()
-    await goToNewWindowHandle(driver, handlesBeforeConnect, handlesAfterConnect)
-    await connectWallet.checkOnConnectWallet()
-    await connectWallet.approveConnectionAndCheckSuccess()
-    expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
-    await navigateToExtensionLandingPage(driver)
-    expect((await apiHelper.listConnections()).length).toBe(1)
+    await runTestRetryIfDriverCrashes(async () => {
+      const { handlesBeforeConnect, handlesAfterConnect } = await sendConnectionRequestAndReturnHandles()
+      await goToNewWindowHandle(driver, handlesBeforeConnect, handlesAfterConnect)
+      await connectWallet.checkOnConnectWallet()
+      await connectWallet.approveConnectionAndCheckSuccess()
+      expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
+      await navigateToExtensionLandingPage(driver)
+      expect((await apiHelper.listConnections()).length).toBe(1)
+    }, 0)
   })
 
   it('connection request persists when popout dismissed', async () => {
     // 1113-POPT-002 If I close the pop-up window the connection persists
-    const { handlesBeforeConnect, handlesAfterConnect } = await sendConnectionRequestAndReturnHandles()
-    await goToNewWindowHandle(driver, handlesBeforeConnect, handlesAfterConnect)
-    await connectWallet.checkOnConnectWallet()
-    await driver.close()
-    expect(await windowHandleHasCount(driver, 2)).toBe(true)
+    await runTestRetryIfDriverCrashes(async () => {
+      const { handlesBeforeConnect, handlesAfterConnect } = await sendConnectionRequestAndReturnHandles()
+      await goToNewWindowHandle(driver, handlesBeforeConnect, handlesAfterConnect)
+      await connectWallet.checkOnConnectWallet()
+      await driver.close()
+      expect(await windowHandleHasCount(driver, 2)).toBe(true)
 
-    await switchWindowHandles(driver, false, originalHandle)
-    await navigateToExtensionLandingPage(driver)
-    await connectWallet.checkOnConnectWallet()
+      await switchWindowHandles(driver, false, originalHandle)
+      await navigateToExtensionLandingPage(driver)
+      await connectWallet.checkOnConnectWallet()
+    }, 0)
   })
 
   it('connect request opens in popout and can be denied when extension not already open', async () => {
     // 1113-POPT-004 If I reject the connection the pop-up window closes
-    const { handlesBeforeConnect, handlesAfterConnect } = await sendConnectionRequestAndReturnHandles()
-    await goToNewWindowHandle(driver, handlesBeforeConnect, handlesAfterConnect)
-    await connectWallet.checkOnConnectWallet()
-    await connectWallet.denyConnection()
-    expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
+    await runTestRetryIfDriverCrashes(async () => {
+      const { handlesBeforeConnect, handlesAfterConnect } = await sendConnectionRequestAndReturnHandles()
+      await goToNewWindowHandle(driver, handlesBeforeConnect, handlesAfterConnect)
+      await connectWallet.checkOnConnectWallet()
+      await connectWallet.denyConnection()
+      expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
+    }, 0)
   })
 
   it('transaction request persists when popout dismissed without response', async () => {
     // 1113-POPT-006 If I close the pop-up window the transaction persists
-    const { handlesBeforeTransaction, handlesAfterTransaction } = await sendTransactionAndGetWindowHandles()
-    await goToNewWindowHandle(driver, handlesBeforeTransaction, handlesAfterTransaction)
-    await transaction.checkOnTransactionPage()
-    await driver.close()
+    await runTestRetryIfDriverCrashes(async () => {
+      const { handlesBeforeTransaction, handlesAfterTransaction } = await sendTransactionAndGetWindowHandles()
+      await goToNewWindowHandle(driver, handlesBeforeTransaction, handlesAfterTransaction)
+      await transaction.checkOnTransactionPage()
+      await driver.close()
 
-    await switchWindowHandles(driver, false)
-    await navigateToExtensionLandingPage(driver)
-    await transaction.checkOnTransactionPage()
+      await switchWindowHandles(driver, false)
+      await navigateToExtensionLandingPage(driver)
+      await transaction.checkOnTransactionPage()
+    }, 0)
   })
 
   it('transaction request opens in popout and can be confirmed when extension not already open', async () => {
     // 1113-POPT-005 The browser wallet opens in a pop-up window when there is a transaction request
     // 1113-POPT-007 If I approve the transaction the pop-up window closes
-    const { handlesBeforeTransaction, handlesAfterTransaction } = await sendTransactionAndGetWindowHandles()
-    await goToNewWindowHandle(driver, handlesBeforeTransaction, handlesAfterTransaction)
-    await transaction.checkOnTransactionPage()
-    await transaction.confirmTransaction()
-    expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
+    await runTestRetryIfDriverCrashes(async () => {
+      const { handlesBeforeTransaction, handlesAfterTransaction } = await sendTransactionAndGetWindowHandles()
+      await goToNewWindowHandle(driver, handlesBeforeTransaction, handlesAfterTransaction)
+      await transaction.checkOnTransactionPage()
+      await transaction.confirmTransaction()
+      expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
+    }, 0)
   })
 
   it('transaction request opens in popout and can be rejected when extension not already open', async () => {
-    // 1113-POPT-008 If I reject the transaction the pop-up window closes
-    const { handlesBeforeTransaction, handlesAfterTransaction } = await sendTransactionAndGetWindowHandles()
-    await goToNewWindowHandle(driver, handlesBeforeTransaction, handlesAfterTransaction)
-    await transaction.checkOnTransactionPage()
-    await transaction.rejectTransaction()
-    expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
+    await runTestRetryIfDriverCrashes(async () => {
+      // 1113-POPT-008 If I reject the transaction the pop-up window closes
+      const { handlesBeforeTransaction, handlesAfterTransaction } = await sendTransactionAndGetWindowHandles()
+      await goToNewWindowHandle(driver, handlesBeforeTransaction, handlesAfterTransaction)
+      await transaction.checkOnTransactionPage()
+      await transaction.rejectTransaction()
+      expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
+    }, 0)
   })
 
   async function sendTransactionAndGetWindowHandles() {

--- a/test/e2e/popout.spec.ts
+++ b/test/e2e/popout.spec.ts
@@ -45,7 +45,7 @@ describe('check popout functionality', () => {
       expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
       await navigateToExtensionLandingPage(driver)
       expect((await apiHelper.listConnections()).length).toBe(1)
-    }, 0)
+    })
   })
 
   it('connection request persists when popout dismissed', async () => {
@@ -60,7 +60,7 @@ describe('check popout functionality', () => {
       await switchWindowHandles(driver, false, originalHandle)
       await navigateToExtensionLandingPage(driver)
       await connectWallet.checkOnConnectWallet()
-    }, 0)
+    })
   })
 
   it('connect request opens in popout and can be denied when extension not already open', async () => {
@@ -71,7 +71,7 @@ describe('check popout functionality', () => {
       await connectWallet.checkOnConnectWallet()
       await connectWallet.denyConnection()
       expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
-    }, 0)
+    })
   })
 
   it('transaction request persists when popout dismissed without response', async () => {
@@ -85,7 +85,7 @@ describe('check popout functionality', () => {
       await switchWindowHandles(driver, false)
       await navigateToExtensionLandingPage(driver)
       await transaction.checkOnTransactionPage()
-    }, 0)
+    })
   })
 
   it('transaction request opens in popout and can be confirmed when extension not already open', async () => {
@@ -97,7 +97,7 @@ describe('check popout functionality', () => {
       await transaction.checkOnTransactionPage()
       await transaction.confirmTransaction()
       expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
-    }, 0)
+    })
   })
 
   it('transaction request opens in popout and can be rejected when extension not already open', async () => {
@@ -108,7 +108,7 @@ describe('check popout functionality', () => {
       await transaction.checkOnTransactionPage()
       await transaction.rejectTransaction()
       expect(await isDriverInstanceClosed(driver, originalHandle)).toBe(true)
-    }, 0)
+    })
   })
 
   async function sendTransactionAndGetWindowHandles() {


### PR DESCRIPTION
The last flake. Tests should be green EVERY TIME. If you see anything fail please tell me. Should only fail for genuine issues. This was the last flake. The fix is minging and I am not proud of it, however this accommodates for what I believe to be selenium's rubishness with extension popout functionality, not our own flakiness. Driver instance just falls over on some occasions after accepting/rejecting a popout resulting in the popout auto closing. It does not like handles disappearing underneath its feet. We catch the ECONNREFUSED exception and retry _only_ if it is that exception. Will fail if it happens multiple times. Ths flake is infrequent enough that it would be incredibly unusual for it to fail multiple times, so if this happens it suggests something is genuinely sideways.