### PR TITLE
test: fix resiliency race condition

### DIFF
--- a/frontend/components/receipts/utils/receipt-wrapper.tsx
+++ b/frontend/components/receipts/utils/receipt-wrapper.tsx
@@ -20,8 +20,6 @@ export const ReceiptWrapper = ({ children, errors = [] }: { children: ReactNode;
   }))
   const allErrors = [assetsError, marketsError, ...errors].filter(Boolean) as Error[]
   const hasError = allErrors.length > 0
-  console.log('*********')
-  console.log(allErrors)
   return (
     <VegaSection>
       {!hasError && <section data-testid={locators.receiptWrapper}>{children}</section>}

--- a/frontend/components/receipts/utils/receipt-wrapper.tsx
+++ b/frontend/components/receipts/utils/receipt-wrapper.tsx
@@ -20,6 +20,8 @@ export const ReceiptWrapper = ({ children, errors = [] }: { children: ReactNode;
   }))
   const allErrors = [assetsError, marketsError, ...errors].filter(Boolean) as Error[]
   const hasError = allErrors.length > 0
+  console.log('*********')
+  console.log(allErrors)
   return (
     <VegaSection>
       {!hasError && <section data-testid={locators.receiptWrapper}>{children}</section>}

--- a/test/resillience-tests/helpers.ts
+++ b/test/resillience-tests/helpers.ts
@@ -1,0 +1,8 @@
+import test from '../../config/test'
+import { ServerConfig, createServer } from '../e2e/helpers/wallet/http-server'
+
+export async function startServer(config: ServerConfig = {}) {
+  const sv = createServer(config)
+  sv.listen(test.test.mockPort)
+  return sv
+}

--- a/test/resillience-tests/transaction-views.spec.tsx
+++ b/test/resillience-tests/transaction-views.spec.tsx
@@ -1,0 +1,70 @@
+import { WebDriver } from 'selenium-webdriver'
+import { captureScreenshot } from '../e2e/helpers/driver'
+import { createWalletAndDriver, navigateToExtensionLandingPage } from '../e2e/helpers/wallet/wallet-setup'
+import { closeServerAndWait } from '../e2e/helpers/wallet/http-server'
+import { Server } from 'http'
+import { VegaAPI } from '../e2e/helpers/wallet/vega-api'
+import { ConnectWallet } from '../e2e/page-objects/connect-wallet'
+import { Transaction } from '../e2e/page-objects/transaction'
+import { dummyTransaction } from '../e2e/helpers/wallet/common-wallet-values'
+import { startServer } from './helpers'
+
+describe('Transaction views are resilient to node outages', () => {
+  let driver: WebDriver
+  let server: Server
+  let closeServer: boolean
+  let vegaAPI: VegaAPI
+  let connectWallet: ConnectWallet
+  let transaction: Transaction
+
+  async function connectWalletAndSendTransaction() {
+    await vegaAPI.connectWalletAndCheckSuccess()
+    await connectWallet.checkOnConnectWallet()
+    await connectWallet.approveConnectionAndCheckSuccess()
+    const keys = await vegaAPI.listKeys()
+    await vegaAPI.sendTransaction(keys[0].publicKey, { transfer: dummyTransaction })
+  }
+
+  beforeEach(async () => {
+    driver = await createWalletAndDriver()
+    vegaAPI = new VegaAPI(driver)
+    connectWallet = new ConnectWallet(driver)
+    transaction = new Transaction(driver)
+    closeServer = true
+  })
+
+  afterEach(async () => {
+    if (closeServer) {
+      await closeServerAndWait(server)
+    }
+    await captureScreenshot(driver, expect.getState().currentTestName as string)
+    await driver.quit()
+  })
+
+  const testCases = [
+    { name: 'no nodes available', options: {}, startServer: false, expectError: true },
+    { name: 'market endpoint is down', options: { includeMarkets: false }, startServer: true, expectError: true },
+    { name: 'assets endpoint is down', options: { includeAssets: false }, startServer: true, expectError: true },
+    { name: 'accounts endpoint is down', options: { includeAccounts: false }, startServer: true, expectError: false },
+    {
+      name: 'blockchain height endpoint is down',
+      options: { includeBlockchainHeight: false },
+      startServer: true,
+      expectError: true
+    },
+    { name: 'all endpoints available', options: {}, startServer: true, expectError: false }
+  ]
+
+  testCases.forEach((testCase) => {
+    it(`shows the appropriate view when ${testCase.name}`, async () => {
+      if (testCase.startServer) {
+        server = await startServer(testCase.options)
+      }
+      await navigateToExtensionLandingPage(driver)
+
+      await connectWalletAndSendTransaction()
+      expect(await transaction.isErrorLoadingDataDisplayed()).toBe(testCase.expectError)
+      closeServer = testCase.startServer
+    })
+  })
+})


### PR DESCRIPTION
There was a race condition where if there server did not start before the test ran no healthy node could be found resulting in errors. We now only navigate to the app after we have started the server to prevent this happening.

Refactored the files so that each set of resiliency behaviour in it's own file