### PR TITLE
fix: execute content-script on document_start

### DIFF
--- a/manifests/chrome.json
+++ b/manifests/chrome.json
@@ -14,7 +14,7 @@
     "default_popup": "index.html"
   },
   "background": {
-    "service_worker": "./background.js"
+    "service_worker": "background.js"
   },
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
@@ -22,7 +22,7 @@
   "permissions": ["offscreen"],
   "web_accessible_resources": [
     {
-      "resources": ["/in-page.js"],
+      "resources": ["in-page.js"],
       "matches": ["<all_urls>"]
     }
   ]

--- a/manifests/chrome.json
+++ b/manifests/chrome.json
@@ -25,12 +25,5 @@
       "resources": ["/in-page.js"],
       "matches": ["<all_urls>"]
     }
-  ],
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["./content-script.js"],
-      "run_at": "document_end"
-    }
   ]
 }

--- a/manifests/common.json
+++ b/manifests/common.json
@@ -9,5 +9,12 @@
     "96": "__ICON_PREFIX__-96x96.png",
     "128": "__ICON_PREFIX__-128x128.png"
   },
-  "permissions": ["storage"]
+  "permissions": ["storage"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["./content-script.js"],
+      "run_at": "document_start"
+    }
+  ]
 }

--- a/manifests/common.json
+++ b/manifests/common.json
@@ -13,7 +13,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["./content-script.js"],
+      "js": ["content-script.js"],
       "run_at": "document_start"
     }
   ]

--- a/manifests/firefox.json
+++ b/manifests/firefox.json
@@ -26,12 +26,5 @@
     "scripts": ["./background.js"]
   },
   "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'",
-  "web_accessible_resources": ["/in-page.js"],
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["./content-script.js"],
-      "run_at": "document_end"
-    }
-  ]
+  "web_accessible_resources": ["/in-page.js"]
 }

--- a/manifests/firefox.json
+++ b/manifests/firefox.json
@@ -23,8 +23,8 @@
     "default_popup": "index.html"
   },
   "background": {
-    "scripts": ["./background.js"]
+    "scripts": ["background.js"]
   },
   "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'",
-  "web_accessible_resources": ["/in-page.js"]
+  "web_accessible_resources": ["in-page.js"]
 }

--- a/manifests/safari.json
+++ b/manifests/safari.json
@@ -22,12 +22,5 @@
     "service_worker": "background.js"
   },
   "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'",
-  "web_accessible_resources": ["in-page.js"],
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["content-script.js"],
-      "run_at": "document_end"
-    }
-  ]
+  "web_accessible_resources": ["in-page.js"]
 }

--- a/web-extension/backend/windows.js
+++ b/web-extension/backend/windows.js
@@ -4,7 +4,7 @@ const windows = globalThis.browser?.windows ?? globalThis.chrome?.windows
 const runtime = globalThis.browser?.runtime ?? globalThis.chrome?.runtime
 
 export const createWindow = (top = undefined, left = undefined, once = false) => {
-  const url = once ? '/index.html?once=1' : '/index.html'
+  const url = once ? 'index.html?once=1' : 'index.html'
   return windows.create({
     url: runtime.getURL(url),
     type: 'popup',


### PR DESCRIPTION
This makes it possible to access the `window.vega` API in inline scripts without waiting for onload or document ready events