### PR TITLE
chore: add some buffer height as firefox no longer seems to respect resize

### DIFF
--- a/web-extension/backend/windows.js
+++ b/web-extension/backend/windows.js
@@ -3,6 +3,8 @@ import { CONSTANTS } from '../../lib/constants'
 const windows = globalThis.browser?.windows ?? globalThis.chrome?.windows
 const runtime = globalThis.browser?.runtime ?? globalThis.chrome?.runtime
 
+const BUFFER_HEIGHT = 30
+
 export const createWindow = (top = undefined, left = undefined, once = false) => {
   const url = once ? 'index.html?once=1' : 'index.html'
   return windows.create({
@@ -12,7 +14,7 @@ export const createWindow = (top = undefined, left = undefined, once = false) =>
     // Approximate dimension. The client figures out exactly how big it should be as this height/width
     // includes the frame and different OSes have different sizes
     width: CONSTANTS.width,
-    height: CONSTANTS.defaultHeight,
+    height: CONSTANTS.defaultHeight + BUFFER_HEIGHT,
     top,
     left
   })

--- a/web-extension/test/admin-ns.spec.js
+++ b/web-extension/test/admin-ns.spec.js
@@ -390,7 +390,7 @@ describe('admin-ns', () => {
       url: 'moz-extension://8b413e68-1e0d-4cad-b98e-1eb000799783/index.html',
       type: 'popup',
       width: CONSTANTS.width,
-      height: CONSTANTS.defaultHeight,
+      height: CONSTANTS.defaultHeight + 30,
       focused: true,
       left: undefined,
       top: undefined


### PR DESCRIPTION
When the popout was opened on MacOS in Firefox the nav buttons were partially off the screen. This fixes that, ensure that the buttons are now shown.