### PR TITLE
fix: position decimals

### DIFF
--- a/frontend/hooks/format-asset-amount/format-asset-amount.spec.tsx
+++ b/frontend/hooks/format-asset-amount/format-asset-amount.spec.tsx
@@ -66,4 +66,18 @@ describe('useFormatAssetAmount', () => {
     expect(result.current?.formattedAmount).toBe('0.000000000123')
     expect(result.current?.symbol).toBe('SYMBOL')
   })
+
+  it('handles decimals as 0', () => {
+    mockStore(useAssetsStore, {
+      getAssetById: () => ({
+        details: {
+          symbol: 'SYMBOL',
+          decimals: 0
+        }
+      })
+    })
+    const { result } = renderHook(() => useFormatAssetAmount('foo', '123'))
+    expect(result.current?.formattedAmount).toBe('123')
+    expect(result.current?.symbol).toBe('SYMBOL')
+  })
 })

--- a/frontend/hooks/format-asset-amount/format-asset-amount.tsx
+++ b/frontend/hooks/format-asset-amount/format-asset-amount.tsx
@@ -12,7 +12,8 @@ export const useFormatAssetAmount = (assetId?: string, amount?: string) => {
   const assetInfo = getAssetById(assetId)
   const decimals = Number(get(assetInfo, 'details.decimals'))
   const symbol = get(assetInfo, 'details.symbol')
-  if (!symbol || !decimals)
+  const noDecimals = !decimals && decimals !== 0
+  if (!symbol || noDecimals)
     throw new Error(`Could not find amount, decimals or symbol when trying to render transaction for asset ${assetId}`)
   const formattedAmount = formatNumber(toBigNum(amount, decimals), decimals)
   return { formattedAmount, symbol }

--- a/frontend/hooks/format-size-amount/format-size-amount.spec.tsx
+++ b/frontend/hooks/format-size-amount/format-size-amount.spec.tsx
@@ -42,6 +42,16 @@ describe('useFormatSizeAmount', () => {
     expect(result.current).toBe('0.000000000123')
   })
 
+  it('allows positionDecimals to be 0', () => {
+    mockStore(useMarketsStore, {
+      getMarketById: () => ({
+        positionDecimalPlaces: 0
+      })
+    })
+    const { result } = renderHook(() => useFormatSizeAmount('foo', '123'))
+    expect(result.current).toBe('123')
+  })
+
   it('returns max when size is max safe integer', () => {
     mockStore(useMarketsStore, {
       getMarketById: () => ({

--- a/frontend/hooks/format-size-amount/format-size-amount.tsx
+++ b/frontend/hooks/format-size-amount/format-size-amount.tsx
@@ -13,6 +13,8 @@ export const useFormatSizeAmount = (marketId?: string, size?: string) => {
   if (size === HALF_MAX_POSITION_SIZE) return 'Max'
   const market = getMarketById(marketId)
   const positionDecimals = Number(get(market, 'positionDecimalPlaces'))
-  if (!market || !positionDecimals) throw new Error('Could not find market or positionDecimals')
+  const noPositionDecimals = !positionDecimals && positionDecimals !== 0
+
+  if (!market || noPositionDecimals) throw new Error('Could not find market or positionDecimals')
   return formatNumber(toBigNum(size, positionDecimals), positionDecimals)
 }


### PR DESCRIPTION
When position decimals or decimals are 0 then errors were being incorrectly thrown for receipt views