### PR TITLE
feat: inform user of auto confirmed transactions

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
     ],
     'unicorn/no-null': 'off',
     'unicorn/no-array-reduce': 'off',
+    'unicorn/no-nested-ternary': 'off',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
     // Reduces bundle size

--- a/frontend/components/modals/transaction-modal/sections/auto-approval-notification.spec.tsx
+++ b/frontend/components/modals/transaction-modal/sections/auto-approval-notification.spec.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { TransactionMessage } from '@/lib/transactions'
+import { useConnectionStore } from '@/stores/connections'
+import { mockStore } from '@/test-helpers/mock-store'
+import { silenceErrors } from '@/test-helpers/silence-errors'
+
+import { testingNetwork } from '../../../../../config/well-known-networks'
+import { locators, TransactionNotAutoApproved } from './auto-approval-notification'
+
+jest.mock('@/stores/connections')
+
+const transaction = {
+  orderSubmission: {
+    marketId: '10c7d40afd910eeac0c2cad186d79cb194090d5d5f13bd31e14c49fd1bded7e2',
+    price: '0',
+    size: '64',
+    side: 'SIDE_SELL',
+    timeInForce: 'TIME_IN_FORCE_GTT',
+    expiresAt: '1678959957494396062',
+    type: 'TYPE_LIMIT',
+    reference: 'traderbot',
+    peggedOrder: {
+      reference: 'PEGGED_REFERENCE_BEST_ASK',
+      offset: '15'
+    }
+  }
+}
+
+const details = {
+  name: 'Key 1',
+  origin: 'https://www.google.com',
+  wallet: 'test-wallet',
+  sendingMode: 'TYPE_SYNC',
+  publicKey: '3fd42fd5ceb22d99ac45086f1d82d516118a5cb7ad9a2e096cd78ca2c8960c80',
+  transaction,
+  chainId: testingNetwork.chainId,
+  receivedAt: new Date('2021-01-01T00:00:00.000Z').toISOString()
+}
+
+const renderComponent = ({ details }: { details: TransactionMessage }) =>
+  render(<TransactionNotAutoApproved details={details} />)
+
+describe('TransactionNotAutoApproved', () => {
+  it('throws error if the connection could not be found', () => {
+    mockStore(useConnectionStore, {
+      connections: []
+    })
+    // silenceErrors()
+    expect(() => renderComponent({ details })).toThrow('')
+  })
+  it('renders nothing if this connection does not have auto approval enabled', () => {
+    mockStore(useConnectionStore, {
+      connections: [{ origin: details.origin, autoConsent: false }]
+    })
+    const { container } = renderComponent({ details })
+    expect(container).toBeEmptyDOMElement()
+  })
+  it('renders nothing if the transactions is not able to be auto approved', () => {
+    mockStore(useConnectionStore, {
+      connections: [{ origin: details.origin, autoConsent: true }]
+    })
+    const { container } = renderComponent({
+      details: {
+        ...details,
+        transaction: { transfer: {} }
+      }
+    })
+    expect(container).toBeEmptyDOMElement()
+  })
+  it('renders message and tooltip if the transaction could have been auto approved but was not', async () => {
+    mockStore(useConnectionStore, {
+      connections: [{ origin: details.origin, autoConsent: true }]
+    })
+    renderComponent({
+      details
+    })
+    expect(screen.getByTestId(locators.autoApprovalMessage)).toHaveTextContent(
+      'Transaction not automatically confirmed'
+    )
+    fireEvent.pointerMove(screen.getByTestId(locators.autoApprovalMessage))
+    await screen.findByRole('tooltip')
+    expect(screen.queryByRole('tooltip')).toHaveTextContent(
+      'This transaction was not automatically confirmed because it was received while your wallet was locked.'
+    )
+  })
+})

--- a/frontend/components/modals/transaction-modal/sections/auto-approval-notification.spec.tsx
+++ b/frontend/components/modals/transaction-modal/sections/auto-approval-notification.spec.tsx
@@ -43,10 +43,10 @@ const renderComponent = ({ details }: { details: TransactionMessage }) =>
 
 describe('TransactionNotAutoApproved', () => {
   it('throws error if the connection could not be found', () => {
+    silenceErrors()
     mockStore(useConnectionStore, {
       connections: []
     })
-    // silenceErrors()
     expect(() => renderComponent({ details })).toThrow('')
   })
   it('renders nothing if this connection does not have auto approval enabled', () => {

--- a/frontend/components/modals/transaction-modal/sections/auto-approval-notification.tsx
+++ b/frontend/components/modals/transaction-modal/sections/auto-approval-notification.tsx
@@ -1,0 +1,27 @@
+import { Intent, Notification, Tooltip } from '@vegaprotocol/ui-toolkit'
+
+import type { TransactionMessage } from '@/lib/transactions'
+import { useConnectionStore } from '@/stores/connections'
+
+import { AUTO_CONSENT_TRANSACTION_TYPES } from '../../../../../lib/constants'
+import { getTransactionType } from '../../../../../web-extension/backend/tx-helpers'
+
+export const TransactionNotAutoApproved = ({ details }: { details: TransactionMessage }) => {
+  const { connections } = useConnectionStore((state) => ({
+    connections: state.connections
+  }))
+  const connection = connections.find((c) => c.origin === details.origin)
+  if (!connection) throw new Error(`Could not find connection with origin ${details.origin}`)
+  if (!connection.autoConsent) return null
+  if (!AUTO_CONSENT_TRANSACTION_TYPES.includes(getTransactionType(details.transaction))) return null
+  return (
+    <Notification
+      message={
+        <Tooltip description="This transaction was not automatically confirmed because it was received while your wallet was locked.">
+          <span>Transaction not automatically confirmed</span>
+        </Tooltip>
+      }
+      intent={Intent.None}
+    />
+  )
+}

--- a/frontend/components/modals/transaction-modal/sections/auto-approval-notification.tsx
+++ b/frontend/components/modals/transaction-modal/sections/auto-approval-notification.tsx
@@ -23,7 +23,7 @@ export const TransactionNotAutoApproved = ({ details }: { details: TransactionMe
       message={
         <Tooltip
           description={
-            <span data-testid={locators.autoApprovalTooltip}>
+            <span data-testid={locators.autoApprovalTooltip} style={{ maxWidth: 300 }}>
               This transaction was not automatically confirmed because it was received while your wallet was locked.
             </span>
           }

--- a/frontend/components/modals/transaction-modal/sections/auto-approval-notification.tsx
+++ b/frontend/components/modals/transaction-modal/sections/auto-approval-notification.tsx
@@ -1,10 +1,14 @@
 import { Intent, Notification, Tooltip } from '@vegaprotocol/ui-toolkit'
 
-import type { TransactionMessage } from '@/lib/transactions'
+import { getTransactionType, type TransactionMessage } from '@/lib/transactions'
 import { useConnectionStore } from '@/stores/connections'
 
 import { AUTO_CONSENT_TRANSACTION_TYPES } from '../../../../../lib/constants'
-import { getTransactionType } from '../../../../../web-extension/backend/tx-helpers'
+
+export const locators = {
+  autoApprovalMessage: 'auto-approval-message',
+  autoApprovalTooltip: 'auto-approval-tooltip'
+}
 
 export const TransactionNotAutoApproved = ({ details }: { details: TransactionMessage }) => {
   const { connections } = useConnectionStore((state) => ({
@@ -17,8 +21,14 @@ export const TransactionNotAutoApproved = ({ details }: { details: TransactionMe
   return (
     <Notification
       message={
-        <Tooltip description="This transaction was not automatically confirmed because it was received while your wallet was locked.">
-          <span>Transaction not automatically confirmed</span>
+        <Tooltip
+          description={
+            <span data-testid={locators.autoApprovalTooltip}>
+              This transaction was not automatically confirmed because it was received while your wallet was locked.
+            </span>
+          }
+        >
+          <span data-testid={locators.autoApprovalMessage}>Transaction not automatically confirmed</span>
         </Tooltip>
       }
       intent={Intent.None}

--- a/frontend/components/modals/transaction-modal/transaction-modal-footer.tsx
+++ b/frontend/components/modals/transaction-modal/transaction-modal-footer.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 
 import { useJsonRpcClient } from '@/contexts/json-rpc/json-rpc-context'
 import { RpcMethods } from '@/lib/client-rpc-methods'
-import type { Transaction, TransactionMessage } from '@/lib/transactions'
+import { getTransactionType, type TransactionMessage } from '@/lib/transactions'
 import { useConnectionStore } from '@/stores/connections'
 
 import { AUTO_CONSENT_TRANSACTION_TYPES } from '../../../../lib/constants'
@@ -12,10 +12,6 @@ export const locators = {
   transactionModalDenyButton: 'transaction-deny-button',
   transactionModalApproveButton: 'transaction-approve-button',
   transactionModalFooterAutoConsentSection: 'transaction-autoconsent-section'
-}
-
-export function getTransactionType(tx: Transaction) {
-  return Object.keys(tx)[0]
 }
 
 export const TransactionModalFooter = ({

--- a/frontend/components/modals/transaction-modal/transaction-modal.spec.tsx
+++ b/frontend/components/modals/transaction-modal/transaction-modal.spec.tsx
@@ -59,6 +59,10 @@ jest.mock('./sections/check-transaction', () => ({
   CheckTransaction: () => <div data-testid="check-transaction" />
 }))
 
+jest.mock('./sections/auto-approval-notification', () => ({
+  TransactionNotAutoApproved: () => <div data-testid="auto-approval-notification" />
+}))
+
 describe('TransactionModal', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -97,6 +101,7 @@ describe('TransactionModal', () => {
     expect(screen.getByTestId('check-transaction')).toBeVisible()
     expect(screen.getByTestId('transaction-header')).toBeVisible()
     expect(screen.getByTestId('transaction-footer')).toBeVisible()
+    expect(screen.getByTestId('auto-approval-notification')).toBeVisible()
     expect(screen.getByTestId(genericLocators.pageHeader)).toBeVisible()
     expect(screen.getByTestId(locators.transactionWrapper)).toBeVisible()
     expect(screen.getByTestId(locators.transactionTimeAgo)).toHaveTextContent('Received just now')

--- a/frontend/components/modals/transaction-modal/transaction-modal.tsx
+++ b/frontend/components/modals/transaction-modal/transaction-modal.tsx
@@ -4,6 +4,7 @@ import { useInteractionStore } from '@/stores/interaction-store'
 
 import { PageHeader } from '../../page-header'
 import { Splash } from '../../splash'
+import { TransactionNotAutoApproved } from './sections/auto-approval-notification'
 import { CheckTransaction } from './sections/check-transaction'
 import { EnrichedDetails } from './sections/enriched-details'
 import { RawTransaction } from './sections/raw-transaction'
@@ -27,6 +28,7 @@ export const TransactionModal = () => {
     <>
       <Splash data-testid={locators.transactionWrapper}>
         <PageHeader />
+
         <section className="pb-4 pt-2 px-5">
           <TransactionHeader
             origin={details.origin}
@@ -34,6 +36,7 @@ export const TransactionModal = () => {
             name={details.name}
             transaction={details.transaction}
           />
+          <TransactionNotAutoApproved details={details} />
           <CheckTransaction publicKey={details.publicKey} transaction={details.transaction} origin={details.origin} />
           <EnrichedDetails transaction={details.transaction} />
           <RawTransaction transaction={details.transaction} />

--- a/frontend/lib/transactions.ts
+++ b/frontend/lib/transactions.ts
@@ -108,3 +108,7 @@ export type IcebergOptions = {
   peakSize: string
   minimumVisibleSize: string
 }
+
+export function getTransactionType(tx: Transaction) {
+  return Object.keys(tx)[0]
+}

--- a/frontend/routes/auth/transactions/details/transaction-data.spec.tsx
+++ b/frontend/routes/auth/transactions/details/transaction-data.spec.tsx
@@ -31,6 +31,7 @@ describe('TransactionData', () => {
       decision: new Date().toISOString(),
       state: TransactionState.Confirmed,
       node: 'https://node.com',
+      autoApproved: false,
       error: undefined,
       hash: undefined,
       code: undefined

--- a/frontend/routes/auth/transactions/details/transaction-metadata.spec.tsx
+++ b/frontend/routes/auth/transactions/details/transaction-metadata.spec.tsx
@@ -37,6 +37,7 @@ const mockTransaction = {
   decision: new Date(0).toISOString(),
   state: TransactionState.Confirmed,
   node: 'https://node.com',
+  autoApproved: false,
   error: undefined,
   hash: '0'.repeat(64),
   code: undefined

--- a/frontend/routes/auth/transactions/details/transaction-metadata.tsx
+++ b/frontend/routes/auth/transactions/details/transaction-metadata.tsx
@@ -98,7 +98,7 @@ export const TransactionMetadata = ({ transaction }: TransactionSectionPropertie
       >
         <Tooltip
           description={
-            <span>
+            <span style={{ maxWidth: 300 }}>
               The auto consent setting can be found and changed under{' '}
               <NavLink
                 className="text-white underline"

--- a/frontend/routes/auth/transactions/details/transaction-metadata.tsx
+++ b/frontend/routes/auth/transactions/details/transaction-metadata.tsx
@@ -96,7 +96,20 @@ export const TransactionMetadata = ({ transaction }: TransactionSectionPropertie
         key="transaction-details-automatically-confirmed"
         data-testid={locators.transactionMetadataAutomaticallyConfirmed}
       >
-        <Tooltip description="You can permit certain dApps to bypass transaction confirmation. This setting can be found and changed in the connection details screen.">
+        <Tooltip
+          description={
+            <span>
+              This setting can be found and changed under
+              <NavLink
+                className="text-white underline"
+                to={`${FULL_ROUTES.connections}/${encodeURIComponent(transaction.origin)}`}
+              >
+                Connections
+              </NavLink>
+              .
+            </span>
+          }
+        >
           <span>{transaction.autoApproved === undefined ? '-' : transaction.autoApproved ? '👍' : '👎'}</span>
         </Tooltip>
       </div>

--- a/frontend/routes/auth/transactions/details/transaction-metadata.tsx
+++ b/frontend/routes/auth/transactions/details/transaction-metadata.tsx
@@ -99,7 +99,7 @@ export const TransactionMetadata = ({ transaction }: TransactionSectionPropertie
         <Tooltip
           description={
             <span>
-              This setting can be found and changed under
+              The auto consent setting can be found and changed under{' '}
               <NavLink
                 className="text-white underline"
                 to={`${FULL_ROUTES.connections}/${encodeURIComponent(transaction.origin)}`}

--- a/frontend/routes/auth/transactions/details/transaction-metadata.tsx
+++ b/frontend/routes/auth/transactions/details/transaction-metadata.tsx
@@ -1,4 +1,4 @@
-import { Intent, Notification, truncateMiddle } from '@vegaprotocol/ui-toolkit'
+import { Intent, Notification, Tooltip, truncateMiddle } from '@vegaprotocol/ui-toolkit'
 import type { ReactNode } from 'react'
 import { NavLink } from 'react-router-dom'
 
@@ -19,7 +19,8 @@ export const locators = {
   transactionMetadataNetwork: 'transaction-metadata-network',
   transactionMetadataNode: 'transaction-metadata-node',
   transactionMetadataOrigin: 'transaction-metadata-origin',
-  transactionMetadataSent: 'transaction-metadata-sent'
+  transactionMetadataSent: 'transaction-metadata-sent',
+  transactionMetadataAutomaticallyConfirmed: 'transaction-metadata-automatically-confirmed'
 }
 
 interface TransactionSectionProperties {
@@ -87,6 +88,17 @@ export const TransactionMetadata = ({ transaction }: TransactionSectionPropertie
       'Sent',
       <div key="transaction-details-sent" data-testid={locators.transactionMetadataSent}>
         {formatDateTime(new Date(transaction.receivedAt).getTime())}
+      </div>
+    ],
+    [
+      'Automatically Confirmed',
+      <div
+        key="transaction-details-automatically-confirmed"
+        data-testid={locators.transactionMetadataAutomaticallyConfirmed}
+      >
+        <Tooltip description="This can be changed in the connection details screen">
+          <span>{transaction.autoApproved ? '👍' : '👎'}</span>
+        </Tooltip>
       </div>
     ]
   ].filter(Boolean) as [ReactNode, ReactNode][]

--- a/frontend/routes/auth/transactions/details/transaction-metadata.tsx
+++ b/frontend/routes/auth/transactions/details/transaction-metadata.tsx
@@ -96,8 +96,8 @@ export const TransactionMetadata = ({ transaction }: TransactionSectionPropertie
         key="transaction-details-automatically-confirmed"
         data-testid={locators.transactionMetadataAutomaticallyConfirmed}
       >
-        <Tooltip description="This can be changed in the connection details screen">
-          <span>{transaction.autoApproved ? '👍' : '👎'}</span>
+        <Tooltip description="You can permit certain dApps to bypass transaction confirmation. This setting can be found and changed in the connection details screen.">
+          <span>{transaction.autoApproved === undefined ? '-' : transaction.autoApproved ? '👍' : '👎'}</span>
         </Tooltip>
       </div>
     ]

--- a/frontend/routes/auth/transactions/home/transactions-list/grouped-transactions-list.spec.tsx
+++ b/frontend/routes/auth/transactions/home/transactions-list/grouped-transactions-list.spec.tsx
@@ -37,6 +37,7 @@ describe('GroupedTransactionsList', () => {
             decision: new Date(0).toISOString(),
             state: TransactionState.Confirmed,
             node: 'https://node.com',
+            autoApproved: false,
             error: undefined,
             hash: undefined,
             code: undefined

--- a/frontend/routes/auth/transactions/home/transactions-list/transactions-list.spec.tsx
+++ b/frontend/routes/auth/transactions/home/transactions-list/transactions-list.spec.tsx
@@ -43,6 +43,7 @@ describe('TransactionList', () => {
         decision: new Date().toISOString(),
         state: TransactionState.Confirmed,
         node: 'https://node.com',
+        autoApproved: false,
         error: undefined,
         hash: undefined,
         code: undefined

--- a/frontend/types/backend.ts
+++ b/frontend/types/backend.ts
@@ -68,6 +68,7 @@ export interface StoredTransaction {
   chainId: string
   decision: string // Date
   state: TransactionState
+  autoApproved: boolean
   node: string
   error?: string
   hash?: string

--- a/web-extension/backend/transactions.js
+++ b/web-extension/backend/transactions.js
@@ -20,7 +20,17 @@ export class TransactionsCollection {
     return { transactions }
   }
 
-  async generateStoreTx({ transaction, publicKey, sendingMode, keyName, walletName, origin, receivedAt, state }) {
+  async generateStoreTx({
+    transaction,
+    publicKey,
+    sendingMode,
+    keyName,
+    walletName,
+    origin,
+    receivedAt,
+    state,
+    autoApproved
+  }) {
     const networkId = await this.connections.getNetworkId(origin)
     const chainId = await this.connections.getChainId(origin)
     return {
@@ -37,6 +47,7 @@ export class TransactionsCollection {
       decision: new Date().toISOString(),
       state,
       receivedAt,
+      autoApproved,
       node: null,
       error: null,
       hash: null,

--- a/web-extension/test/transactions.spec.js
+++ b/web-extension/test/transactions.spec.js
@@ -64,6 +64,7 @@ describe('Transactions', () => {
       sendingMode: 'TYPE_ASYNC',
       keyName: 'key1',
       networkId: 'n1',
+      autoApproved: false,
       chainId: 'c1',
       decision: '1970-01-01T00:00:00.000Z',
       origin: 'https://example.com',

--- a/web-extension/test/transactions.spec.js
+++ b/web-extension/test/transactions.spec.js
@@ -39,7 +39,8 @@ const generateTx = async (connections, transactions) => {
     walletName: 'w1',
     origin: 'https://example.com',
     receivedAt: new Date().toISOString(),
-    state: 'Rejected'
+    state: 'Rejected',
+    autoApproved: false
   })
   return { result, mockTx }
 }


### PR DESCRIPTION
Closes #785 

- Show why a transaction was not auto approved on transaction modal if the user had thier wallet locked
- In transaction list show if a transaction was automatically confirmed or not